### PR TITLE
Include members in findByEventId and LightningTalkRepository updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "0.3.0",
+  "version": "0.3.1-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shizuoka-its/core",
-      "version": "0.3.0",
+      "version": "0.3.1-rc.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shizuoka-its/core",
-      "version": "0.3.1-rc.0",
+      "version": "0.3.1-rc.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "0.3.1-rc.1",
+  "version": "0.3.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shizuoka-its/core",
-      "version": "0.3.1-rc.1",
+      "version": "0.3.1-rc.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "dist",
-    "prisma"
-  ],
+  "files": ["dist", "prisma"],
   "scripts": {
     "postinstall": "prisma generate",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "0.3.1-rc.1",
+  "version": "0.3.1-rc.2",
   "description": "ITS core library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "0.3.0",
+  "version": "0.3.1-rc.0",
   "description": "ITS core library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": ["dist", "prisma"],
+  "files": [
+    "dist",
+    "prisma"
+  ],
   "scripts": {
     "postinstall": "prisma generate",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "0.3.1-rc.0",
+  "version": "0.3.1-rc.1",
   "description": "ITS core library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/repositories/exhibit.repository.ts
+++ b/src/repositories/exhibit.repository.ts
@@ -47,6 +47,13 @@ export class ExhibitRepository
   async findByEventId(eventId: string): Promise<Exhibit[]> {
     return this.prisma.exhibit.findMany({
       where: { eventId },
+      include: {
+        members: {
+          include: {
+            member: true,
+          },
+        },
+      },
     });
   }
 

--- a/src/repositories/lightningTalk.repository.ts
+++ b/src/repositories/lightningTalk.repository.ts
@@ -65,7 +65,17 @@ export class LightningTalkRepository
           eventId,
         },
       },
-      include: { exhibit: true },
+      include: {
+        exhibit: {
+          include: {
+            members: {
+              include: {
+                member: true,
+              },
+            },
+          },
+        },
+      },
     });
   }
 

--- a/src/repositories/lightningTalk.repository.ts
+++ b/src/repositories/lightningTalk.repository.ts
@@ -52,7 +52,17 @@ export class LightningTalkRepository
   ): Promise<(LightningTalk & { exhibit: Exhibit }) | null> {
     return this.prisma.lightningTalk.findUnique({
       where: { exhibitId: id },
-      include: { exhibit: true },
+      include: {
+        exhibit: {
+          include: {
+            members: {
+              include: {
+                member: true,
+              },
+            },
+          },
+        },
+      },
     });
   }
 


### PR DESCRIPTION
Update the `findByEventId` method to include members and modify the `LightningTalkRepository` to include exhibit members. Increment the version to 0.3.1.