### PR TITLE
fix: imports のパスを src から dist に修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
 		}
 	},
 	"imports": {
-		"#domain": "./src/domain/index.js",
-		"#domain/*": "./src/domain/*",
-		"#application": "./src/application/index.js",
-		"#application/*": "./src/application/*",
-		"#infrastructure": "./src/infrastructure/index.js",
-		"#infrastructure/*": "./src/infrastructure/*"
+		"#domain": "./dist/domain/index.js",
+		"#domain/*": "./dist/domain/*",
+		"#application": "./dist/application/index.js",
+		"#application/*": "./dist/application/*",
+		"#infrastructure": "./dist/infrastructure/index.js",
+		"#infrastructure/*": "./dist/infrastructure/*"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
- `imports` のパスを `./src/...` から `./dist/...` に修正

## Reason
Subpath Imports は実行時に Node.js が解決するため、ビルド後の `dist` を参照する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)