### PR TITLE
test: Repository統合テストの追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,13 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
 	"vcs": {
-		"enabled": false,
+		"enabled": true,
 		"clientKind": "git",
-		"useIgnoreFile": false
+		"useIgnoreFile": true
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["dist"]
+		"ignore": ["dist", "coverage"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,71 @@
 				"@biomejs/biome": "1.9.4",
 				"@types/node": "^22.9.0",
 				"@types/pg": "^8.16.0",
+				"@vitest/coverage-v8": "^4.0.18",
 				"drizzle-kit": "^0.31.8",
 				"tsup": "^8.5.1",
 				"typescript": "^5.6.3",
 				"vitest": "^4.0.18"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -1515,6 +1576,37 @@
 				"pg-types": "^2.2.0"
 			}
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+			"integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.0.18",
+				"ast-v8-to-istanbul": "^0.3.10",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.1",
+				"obug": "^2.1.1",
+				"std-env": "^3.10.0",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "4.0.18",
+				"vitest": "4.0.18"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "4.0.18",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -1654,6 +1746,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+			"integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -2041,6 +2145,62 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/joycon": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -2050,6 +2210,13 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lilconfig": {
 			"version": "3.1.3",
@@ -2089,6 +2256,34 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+			"integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.28.5",
+				"@babel/types": "^7.28.5",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mlly": {
@@ -2491,6 +2686,19 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/semver": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2573,6 +2781,19 @@
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@biomejs/biome": "1.9.4",
 		"@types/node": "^22.9.0",
 		"@types/pg": "^8.16.0",
+		"@vitest/coverage-v8": "^4.0.18",
 		"drizzle-kit": "^0.31.8",
 		"tsup": "^8.5.1",
 		"typescript": "^5.6.3",

--- a/tests/repository/DrizzleEventRepository.test.ts
+++ b/tests/repository/DrizzleEventRepository.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
+import type { Event } from "#domain/aggregates/event/Event";
 import { Exhibit } from "#domain/aggregates/event/Exhibit";
+import { LightningTalk } from "#domain/aggregates/event/LightningTalk";
+import { LightningTalkDuration } from "#domain/value-objects";
 import { DrizzleEventRepository } from "#infrastructure/drizzle/DrizzleEventRepository";
+import { DrizzleMemberRepository } from "#infrastructure/drizzle/DrizzleMemberRepository";
 import { createEvent } from "../factories/event";
+import { createMember } from "../factories/member";
 
 describe("DrizzleEventRepository", () => {
 	const repository = new DrizzleEventRepository();
+	const memberRepository = new DrizzleMemberRepository();
 
 	describe("save / findById", () => {
 		it("保存したEventをIDで取得できる", async () => {
@@ -67,6 +73,53 @@ describe("DrizzleEventRepository", () => {
 			expect(found).not.toBeNull();
 			expect(found?.getExhibits()).toHaveLength(0);
 		});
+
+		it("LightningTalk付きExhibitを保存・取得できる", async () => {
+			const event = createEvent();
+			const exhibitId = `exhibit-lt-${Date.now()}`;
+			const lightningTalk = new LightningTalk(
+				exhibitId,
+				new Date("2025-04-01T14:00:00Z"),
+				new LightningTalkDuration(10),
+			);
+			const exhibit = Exhibit.createWithLightningTalk(
+				exhibitId,
+				"LT付き展示",
+				lightningTalk,
+				"説明文",
+			);
+			event.addExhibit(exhibit);
+
+			await repository.save(event);
+			const found = await repository.findById(event.id);
+
+			expect(found).not.toBeNull();
+			expect(found?.getExhibits()).toHaveLength(1);
+			const foundExhibit = found?.getExhibits()[0];
+			expect(foundExhibit?.getName()).toBe("LT付き展示");
+			expect(foundExhibit?.getLightningTalk()).not.toBeUndefined();
+			expect(
+				foundExhibit?.getLightningTalk()?.getDurationMinutes().getValue(),
+			).toBe(10);
+		});
+
+		it("ExhibitにMemberを追加して保存・取得できる", async () => {
+			const member = createMember();
+			await memberRepository.save(member);
+
+			const event = createEvent();
+			const exhibitId = `exhibit-member-${Date.now()}`;
+			const exhibit = new Exhibit(exhibitId, "メンバー付き展示");
+			exhibit.addMemberId(member.id);
+			event.addExhibit(exhibit);
+
+			await repository.save(event);
+			const found = await repository.findById(event.id);
+
+			expect(found).not.toBeNull();
+			const foundExhibit = found?.getExhibits()[0];
+			expect(foundExhibit?.getMemberIds()).toContain(member.id);
+		});
 	});
 
 	describe("delete", () => {
@@ -103,8 +156,86 @@ describe("DrizzleEventRepository", () => {
 			const all = await repository.findAll();
 
 			expect(all.length).toBeGreaterThanOrEqual(2);
-			expect(all.some((e) => e.id === event1.id)).toBe(true);
-			expect(all.some((e) => e.id === event2.id)).toBe(true);
+			expect(all.some((e: Event) => e.id === event1.id)).toBe(true);
+			expect(all.some((e: Event) => e.id === event2.id)).toBe(true);
+		});
+	});
+
+	describe("findByParticipantMemberId", () => {
+		it("参加しているMemberのIDでEventを取得できる", async () => {
+			const member = createMember();
+			await memberRepository.save(member);
+
+			const event = createEvent({ name: "参加イベント" });
+			event.addMemberId(member.id);
+			await repository.save(event);
+
+			const found = await repository.findByParticipantMemberId(member.id);
+
+			expect(found).toHaveLength(1);
+			expect(found[0].id).toBe(event.id);
+			expect(found[0].getMemberIds()).toContain(member.id);
+		});
+
+		it("複数Eventに参加しているMemberは全て取得できる", async () => {
+			const member = createMember();
+			await memberRepository.save(member);
+
+			const event1 = createEvent({ name: "イベント1" });
+			const event2 = createEvent({ name: "イベント2" });
+			event1.addMemberId(member.id);
+			event2.addMemberId(member.id);
+			await repository.save(event1);
+			await repository.save(event2);
+
+			const found = await repository.findByParticipantMemberId(member.id);
+
+			expect(found).toHaveLength(2);
+			expect(found.some((e: Event) => e.id === event1.id)).toBe(true);
+			expect(found.some((e: Event) => e.id === event2.id)).toBe(true);
+		});
+
+		it("参加していないMemberのIDでは空配列を返す", async () => {
+			const member = createMember();
+			await memberRepository.save(member);
+
+			const event = createEvent({ name: "別のイベント" });
+			await repository.save(event);
+
+			const found = await repository.findByParticipantMemberId(member.id);
+
+			expect(found).toHaveLength(0);
+		});
+
+		it("存在しないMemberIDでは空配列を返す", async () => {
+			const found =
+				await repository.findByParticipantMemberId("non-existent-id");
+
+			expect(found).toHaveLength(0);
+		});
+	});
+
+	describe("findByExhibitId", () => {
+		it("ExhibitIDでEventを取得できる", async () => {
+			const event = createEvent({ name: "展示イベント" });
+			const exhibitId = `exhibit-find-${Date.now()}`;
+			const exhibit = new Exhibit(exhibitId, "展示物");
+			event.addExhibit(exhibit);
+			await repository.save(event);
+
+			const found = await repository.findByExhibitId(exhibitId);
+
+			expect(found).not.toBeNull();
+			expect(found?.id).toBe(event.id);
+			expect(
+				found?.getExhibits().some((e: Exhibit) => e.id === exhibitId),
+			).toBe(true);
+		});
+
+		it("存在しないExhibitIDではnullを返す", async () => {
+			const found = await repository.findByExhibitId("non-existent-exhibit-id");
+
+			expect(found).toBeNull();
 		});
 	});
 });

--- a/tests/repository/DrizzleMemberRepository.test.ts
+++ b/tests/repository/DrizzleMemberRepository.test.ts
@@ -44,6 +44,25 @@ describe("DrizzleMemberRepository", () => {
 		});
 	});
 
+	describe("findByStudentId", () => {
+		it("学籍番号でMemberを取得できる", async () => {
+			const member = createMember({ studentId: "99999999" });
+			await repository.save(member);
+
+			const found = await repository.findByStudentId("99999999");
+
+			expect(found).not.toBeNull();
+			expect(found?.id).toBe(member.id);
+			expect(found?.getStudentId()).toBe("99999999");
+		});
+
+		it("存在しない学籍番号はnullを返す", async () => {
+			const found = await repository.findByStudentId("00000000");
+
+			expect(found).toBeNull();
+		});
+	});
+
 	describe("save（更新）", () => {
 		it("既存Memberの名前を更新できる", async () => {
 			const member = createMember({ name: "更新前" });


### PR DESCRIPTION
## Summary
- vitest導入
- DrizzleMemberRepository / DrizzleEventRepository の統合テスト
- テスト用ファクトリー（Member, Event）
- ローカル用 docker-compose.test.yml
- CI用 test.yml ワークフロー

## テスト内容
- 保存→取得
- 更新
- 削除
- 関連エンティティ（DiscordAccount, Exhibit）

## ローカル実行方法
```bash
docker compose -f docker-compose.test.yml up -d
npm run db:push
npm test
```

## 安全機構
- テスト用ポート5433（本番5432と分離）
- DATABASE_URLに`localhost`か`test`がないとエラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)