### PR TITLE
feat: カルテのユースケース（作成・訂正・閲覧）を追加

### DIFF
--- a/src/application/usecase/karte/CorrectKarte.ts
+++ b/src/application/usecase/karte/CorrectKarte.ts
@@ -8,6 +8,7 @@ import type { Karte } from "#domain/aggregates/karte/Karte";
 import type { KarteId } from "#domain/aggregates/karte/KarteId";
 import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
 import type { WorkDuration } from "#domain/aggregates/karte/WorkDuration";
+import type { MemberId } from "#domain/aggregates/member/MemberId";
 import type { NonEmptyArray } from "#domain/base/NonEmptyArray";
 
 /** 訂正時の解決ステータス */
@@ -26,7 +27,7 @@ export type CorrectKarteInput = {
 		readonly troubleDetails: string;
 	};
 	readonly supportRecord: {
-		readonly assignedMemberIds: NonEmptyArray<string>;
+		readonly assignedMemberIds: NonEmptyArray<MemberId>;
 		readonly content: string;
 		readonly resolution: CorrectResolution;
 		readonly workDuration: WorkDuration;

--- a/src/application/usecase/karte/CreateKarte.ts
+++ b/src/application/usecase/karte/CreateKarte.ts
@@ -7,6 +7,7 @@ import { Karte } from "#domain/aggregates/karte/Karte";
 import type { KarteId } from "#domain/aggregates/karte/KarteId";
 import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
 import type { WorkDuration } from "#domain/aggregates/karte/WorkDuration";
+import type { MemberId } from "#domain/aggregates/member/MemberId";
 import type { NonEmptyArray } from "#domain/base/NonEmptyArray";
 
 /** 新規カルテ作成時の解決ステータス */
@@ -25,7 +26,7 @@ export type CreateKarteInput = {
 		readonly troubleDetails: string;
 	};
 	readonly supportRecord: {
-		readonly assignedMemberIds: NonEmptyArray<string>;
+		readonly assignedMemberIds: NonEmptyArray<MemberId>;
 		readonly content: string;
 		readonly resolution: CreateResolution;
 		readonly workDuration: WorkDuration;


### PR DESCRIPTION
## 概要

PR #82 で導入したカルテ集約のドメインモデルに対し、アプリケーション層のユースケースを追加する。

## 変更内容

### 新規ファイル
- `src/application/usecase/karte/CreateKarte.ts` — カルテ新規作成
- `src/application/usecase/karte/CorrectKarte.ts` — カルテの訂正
- `src/application/usecase/karte/GetKarte.ts` — カルテ閲覧
- `src/application/usecase/karte/index.ts` — barrel export

### 変更ファイル
- `src/application/index.ts` — karteユースケースのexportを追加

## 設計の要点

### ユースケースの粒度
- **Create**: `Karte.create()` を呼び出し、全フィールドが揃った状態で新規作成する
- **Correct**: 既存カルテを取得し `karte.correct()` で訂正した新しいインスタンスを保存する。「更新(Update)」ではなく「訂正(Correct)」という業務概念を採用
- **Get**: KarteIdで1件取得

### 旧PR #84からの変更点
| 旧 | 新 | 理由 |
|---|---|---|
| `UpdateKarteUseCase`（部分更新） | `CorrectKarteUseCase`（全フィールド訂正） | Karteがイミュータブル設計になり `correct()` が全内容を受け取る |
| `ListKartesUseCase` + `KarteFilter` | 削除 | Repository が `findById` / `save` のみのYAGNI設計 |
| `Response` 型 | `SupportRecord` 型 | PR #82 での命名変更に追従 |
| `new Karte(...)` | `Karte.create(...)` | コンストラクタが private になりファクトリメソッド経由に |

### 一覧取得について
現時点ではRepositoryに `findAll` を設けていない。一覧取得が必要になった段階で、クエリ専用のRead Modelやビュー層での対応を検討する（CQRSの方向性）。

## テスト計画
- [x] `npx tsc --noEmit` で型チェックパス
- [x] `npx biome check` でリント・フォーマットパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)