### PR TITLE
feat: カルテ集約のアプリケーション層・ドメインモデル拡張

### DIFF
--- a/src/application/exceptions/ApplicationExceptions.ts
+++ b/src/application/exceptions/ApplicationExceptions.ts
@@ -53,6 +53,14 @@ export class MemberNotFoundFromDiscordAccountIdException extends ApplicationExce
 	}
 }
 
+export class KarteNotFoundException extends ApplicationException {
+	constructor(karteId: string) {
+		const message = `カルテが見つかりません: ${karteId}`;
+		super(message);
+		this.name = "KarteNotFoundException";
+	}
+}
+
 export class DiscordAccountNotConnectedException extends ApplicationException {
 	constructor(userId: string, discordUserId: string) {
 		const message = `ユーザー: ${userId} のDiscordアカウントは紐づいていません: ${discordUserId}`;

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -1,4 +1,5 @@
 export * from "./usecase/member";
 export * from "./usecase/event";
 export * from "./usecase/eventParticipation";
+export * from "./usecase/karte";
 export * from "./exceptions";

--- a/src/application/usecase/karte/CorrectKarte.ts
+++ b/src/application/usecase/karte/CorrectKarte.ts
@@ -1,0 +1,58 @@
+import { KarteNotFoundException } from "#application/exceptions";
+import { IUseCase } from "#application/usecase/base";
+import type { Consent } from "#domain/aggregates/karte/Consent";
+import type { ConsultationCategory } from "#domain/aggregates/karte/ConsultationCategory";
+import type { FollowUp } from "#domain/aggregates/karte/FollowUp";
+import { type CompleteClient, Karte } from "#domain/aggregates/karte/Karte";
+import type { KarteId } from "#domain/aggregates/karte/KarteId";
+import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
+import type { WorkDuration } from "#domain/aggregates/karte/WorkDuration";
+import type { MemberId } from "#domain/aggregates/member/MemberId";
+import type { NonEmptyArray } from "#domain/base/NonEmptyArray";
+
+/** 訂正時の解決ステータス */
+type CorrectResolution =
+	| { readonly type: "resolved" }
+	| { readonly type: "unresolved"; readonly followUp: FollowUp };
+
+export type CorrectKarteInput = {
+	readonly karteId: KarteId;
+	readonly consultedAt: Date;
+	readonly client: CompleteClient;
+	readonly consent: Consent;
+	readonly consultation: {
+		readonly categories: NonEmptyArray<ConsultationCategory>;
+		readonly targetDevice: string;
+		readonly troubleDetails: string;
+	};
+	readonly supportRecord: {
+		readonly assignedMemberIds: NonEmptyArray<MemberId>;
+		readonly content: string;
+		readonly resolution: CorrectResolution;
+		readonly workDuration: WorkDuration;
+	};
+};
+
+export type CorrectKarteOutput = {
+	readonly karte: Karte;
+};
+
+export class CorrectKarteUseCase extends IUseCase<
+	CorrectKarteInput,
+	CorrectKarteOutput
+> {
+	constructor(private readonly karteRepository: KarteRepository) {
+		super();
+	}
+
+	async execute(input: CorrectKarteInput): Promise<CorrectKarteOutput> {
+		const existing = await this.karteRepository.findById(input.karteId);
+		if (!existing) {
+			throw new KarteNotFoundException(input.karteId);
+		}
+
+		const corrected = existing.correct(input);
+		await this.karteRepository.save(corrected);
+		return { karte: corrected };
+	}
+}

--- a/src/application/usecase/karte/CreateKarte.ts
+++ b/src/application/usecase/karte/CreateKarte.ts
@@ -1,0 +1,52 @@
+import { IUseCase } from "#application/usecase/base";
+import type { Consent } from "#domain/aggregates/karte/Consent";
+import type { ConsultationCategory } from "#domain/aggregates/karte/ConsultationCategory";
+import type { FollowUp } from "#domain/aggregates/karte/FollowUp";
+import { type CompleteClient, Karte } from "#domain/aggregates/karte/Karte";
+import type { KarteId } from "#domain/aggregates/karte/KarteId";
+import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
+import type { WorkDuration } from "#domain/aggregates/karte/WorkDuration";
+import type { MemberId } from "#domain/aggregates/member/MemberId";
+import type { NonEmptyArray } from "#domain/base/NonEmptyArray";
+
+/** 新規カルテ作成時の解決ステータス */
+type CreateResolution =
+	| { readonly type: "resolved" }
+	| { readonly type: "unresolved"; readonly followUp: FollowUp };
+
+export type CreateKarteInput = {
+	readonly id: KarteId;
+	readonly consultedAt: Date;
+	readonly client: CompleteClient;
+	readonly consent: Consent;
+	readonly consultation: {
+		readonly categories: NonEmptyArray<ConsultationCategory>;
+		readonly targetDevice: string;
+		readonly troubleDetails: string;
+	};
+	readonly supportRecord: {
+		readonly assignedMemberIds: NonEmptyArray<MemberId>;
+		readonly content: string;
+		readonly resolution: CreateResolution;
+		readonly workDuration: WorkDuration;
+	};
+};
+
+export type CreateKarteOutput = {
+	readonly karte: Karte;
+};
+
+export class CreateKarteUseCase extends IUseCase<
+	CreateKarteInput,
+	CreateKarteOutput
+> {
+	constructor(private readonly karteRepository: KarteRepository) {
+		super();
+	}
+
+	async execute(input: CreateKarteInput): Promise<CreateKarteOutput> {
+		const karte = Karte.create(input);
+		await this.karteRepository.save(karte);
+		return { karte };
+	}
+}

--- a/src/application/usecase/karte/GetKarte.ts
+++ b/src/application/usecase/karte/GetKarte.ts
@@ -1,0 +1,27 @@
+import { KarteNotFoundException } from "#application/exceptions";
+import { IUseCase } from "#application/usecase/base";
+import type { Karte } from "#domain/aggregates/karte/Karte";
+import type { KarteId } from "#domain/aggregates/karte/KarteId";
+import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
+
+export type GetKarteInput = {
+	readonly karteId: KarteId;
+};
+
+export type GetKarteOutput = {
+	readonly karte: Karte;
+};
+
+export class GetKarteUseCase extends IUseCase<GetKarteInput, GetKarteOutput> {
+	constructor(private readonly karteRepository: KarteRepository) {
+		super();
+	}
+
+	async execute(input: GetKarteInput): Promise<GetKarteOutput> {
+		const karte = await this.karteRepository.findById(input.karteId);
+		if (!karte) {
+			throw new KarteNotFoundException(input.karteId);
+		}
+		return { karte };
+	}
+}

--- a/src/application/usecase/karte/ImportKarte.ts
+++ b/src/application/usecase/karte/ImportKarte.ts
@@ -1,0 +1,45 @@
+import { IUseCase } from "#application/usecase/base";
+import type { Client } from "#domain/aggregates/karte/Client";
+import type { Consent } from "#domain/aggregates/karte/Consent";
+import type { Consultation } from "#domain/aggregates/karte/Consultation";
+import { Karte } from "#domain/aggregates/karte/Karte";
+import type { KarteId } from "#domain/aggregates/karte/KarteId";
+import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
+import type { Recorded } from "#domain/aggregates/karte/Recorded";
+import type { SupportRecord } from "#domain/aggregates/karte/SupportRecord";
+
+/**
+ * 過去データのインポート用入力
+ *
+ * 新規作成と異なり、一部フィールドが未記録（notRecorded）である可能性がある。
+ * Karte.reconstruct() を使用して不変条件をバイパスする。
+ */
+export type ImportKarteInput = {
+	readonly id: KarteId;
+	readonly recordedAt: Date;
+	readonly consultedAt: Recorded<Date>;
+	readonly lastUpdatedAt: Date;
+	readonly client: Recorded<Client>;
+	readonly consent: Consent;
+	readonly consultation: Consultation;
+	readonly supportRecord: SupportRecord;
+};
+
+export type ImportKarteOutput = {
+	readonly karte: Karte;
+};
+
+export class ImportKarteUseCase extends IUseCase<
+	ImportKarteInput,
+	ImportKarteOutput
+> {
+	constructor(private readonly karteRepository: KarteRepository) {
+		super();
+	}
+
+	async execute(input: ImportKarteInput): Promise<ImportKarteOutput> {
+		const karte = Karte.reconstruct(input);
+		await this.karteRepository.save(karte);
+		return { karte };
+	}
+}

--- a/src/application/usecase/karte/ListKartes.ts
+++ b/src/application/usecase/karte/ListKartes.ts
@@ -1,0 +1,23 @@
+import { IUseCase } from "#application/usecase/base";
+import type { Karte } from "#domain/aggregates/karte/Karte";
+import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
+
+export type ListKartesInput = Record<string, never>;
+
+export type ListKartesOutput = {
+	readonly kartes: readonly Karte[];
+};
+
+export class ListKartesUseCase extends IUseCase<
+	ListKartesInput,
+	ListKartesOutput
+> {
+	constructor(private readonly karteRepository: KarteRepository) {
+		super();
+	}
+
+	async execute(_input: ListKartesInput): Promise<ListKartesOutput> {
+		const kartes = await this.karteRepository.findAll();
+		return { kartes };
+	}
+}

--- a/src/application/usecase/karte/index.ts
+++ b/src/application/usecase/karte/index.ts
@@ -1,0 +1,5 @@
+export { CreateKarteUseCase, type CreateKarteInput, type CreateKarteOutput } from "./CreateKarte";
+export { CorrectKarteUseCase, type CorrectKarteInput, type CorrectKarteOutput } from "./CorrectKarte";
+export { GetKarteUseCase, type GetKarteInput, type GetKarteOutput } from "./GetKarte";
+export { ImportKarteUseCase, type ImportKarteInput, type ImportKarteOutput } from "./ImportKarte";
+export { ListKartesUseCase, type ListKartesInput, type ListKartesOutput } from "./ListKartes";

--- a/src/domain/aggregates/karte/Assignee.ts
+++ b/src/domain/aggregates/karte/Assignee.ts
@@ -1,0 +1,16 @@
+import type { MemberId } from "#domain/aggregates/member/MemberId";
+
+/** システム上のメンバーに紐づく対応者 */
+type ResolvedAssignee = {
+	readonly type: "resolved";
+	readonly memberId: MemberId;
+};
+
+/** メンバーに紐づかない対応者（過去データ等） */
+type UnresolvedAssignee = {
+	readonly type: "unresolved";
+	readonly name: string;
+};
+
+/** 対応者 — カルテの対応を行った人 */
+export type Assignee = ResolvedAssignee | UnresolvedAssignee;

--- a/src/domain/aggregates/karte/Client.ts
+++ b/src/domain/aggregates/karte/Client.ts
@@ -1,4 +1,4 @@
-import type { Affiliation } from "#domain/shared";
+import type { Affiliation, PartialAffiliation } from "#domain/shared";
 import type { StudentId } from "#domain/shared";
 
 /** 学生の相談者 */
@@ -8,8 +8,8 @@ type StudentClient = {
 	readonly studentId: StudentId;
 	/** 氏名 */
 	readonly name: string;
-	/** 所属 */
-	readonly affiliation: Affiliation;
+	/** 所属（完全または部分的） */
+	readonly affiliation: Affiliation | PartialAffiliation;
 };
 
 /** 教員の相談者 */

--- a/src/domain/aggregates/karte/Consultation.ts
+++ b/src/domain/aggregates/karte/Consultation.ts
@@ -6,7 +6,7 @@ import type { Recorded } from "./Recorded";
  * 相談事
  *
  * 相談者が持ち込んだトラブルの内容をまとめた値オブジェクト。
- * カテゴリ・対象機器は過去データで未記録の場合がある。
+ * 過去データでは各フィールドが未記録の場合がある。
  */
 export type Consultation = {
 	/** 相談カテゴリ（複数選択可） */
@@ -14,5 +14,5 @@ export type Consultation = {
 	/** 対象機器 */
 	readonly targetDevice: Recorded<string>;
 	/** トラブル詳細 */
-	readonly troubleDetails: string;
+	readonly troubleDetails: Recorded<string>;
 };

--- a/src/domain/aggregates/karte/Karte.ts
+++ b/src/domain/aggregates/karte/Karte.ts
@@ -1,5 +1,8 @@
 import type { MemberId } from "#domain/aggregates/member/MemberId";
 import type { NonEmptyArray } from "#domain/base/NonEmptyArray";
+import type { Affiliation } from "#domain/shared";
+import type { StudentId } from "#domain/shared";
+import type { Assignee } from "./Assignee";
 import type { Client } from "./Client";
 import type { Consent } from "./Consent";
 import type { Consultation } from "./Consultation";
@@ -20,6 +23,22 @@ type CompleteResolution =
 	  };
 
 /**
+ * 新規作成・訂正時の相談者
+ *
+ * 完全なAffiliationのみ受け付ける。PartialAffiliationは不可。
+ */
+export type CompleteClient =
+	| {
+			readonly type: "student";
+			readonly studentId: StudentId;
+			readonly name: string;
+			readonly affiliation: Affiliation;
+	  }
+	| { readonly type: "teacher"; readonly name: string }
+	| { readonly type: "staff"; readonly name: string }
+	| { readonly type: "other"; readonly name: string };
+
+/**
  * カルテの内容を表す入力型
  *
  * create/correctの共通部分。全フィールドが完全に揃った状態を要求する。
@@ -27,7 +46,7 @@ type CompleteResolution =
  */
 type KarteContentProps = {
 	readonly consultedAt: Date;
-	readonly client: Client;
+	readonly client: CompleteClient;
 	readonly consent: Consent;
 	readonly consultation: {
 		readonly categories: NonEmptyArray<ConsultationCategory>;
@@ -160,15 +179,21 @@ function toConsultation(props: KarteContentProps): Consultation {
 	return {
 		categories: recorded(props.consultation.categories),
 		targetDevice: recorded(props.consultation.targetDevice),
-		troubleDetails: props.consultation.troubleDetails,
+		troubleDetails: recorded(props.consultation.troubleDetails),
 	};
 }
 
 /** 生の入力から SupportRecord（Recorded付き）を構築する */
 function toSupportRecord(props: KarteContentProps): SupportRecord {
+	const [first, ...rest] = props.supportRecord.assignedMemberIds;
+	const assignees: NonEmptyArray<Assignee> = [
+		{ type: "resolved", memberId: first },
+		...rest.map((memberId): Assignee => ({ type: "resolved", memberId })),
+	];
+
 	return {
-		assignedMemberIds: recorded(props.supportRecord.assignedMemberIds),
-		content: props.supportRecord.content,
+		assignees: recorded(assignees),
+		content: recorded(props.supportRecord.content),
 		resolution: recorded(toRecordedResolution(props.supportRecord.resolution)),
 		workDuration: recorded(props.supportRecord.workDuration),
 	};

--- a/src/domain/aggregates/karte/KarteRepository.ts
+++ b/src/domain/aggregates/karte/KarteRepository.ts
@@ -3,5 +3,6 @@ import type { KarteId } from "./KarteId";
 
 export interface KarteRepository {
 	findById(id: KarteId): Promise<Karte | null>;
+	findAll(): Promise<Karte[]>;
 	save(karte: Karte): Promise<void>;
 }

--- a/src/domain/aggregates/karte/SupportRecord.ts
+++ b/src/domain/aggregates/karte/SupportRecord.ts
@@ -1,5 +1,5 @@
-import type { MemberId } from "#domain/aggregates/member/MemberId";
 import type { NonEmptyArray } from "#domain/base/NonEmptyArray";
+import type { Assignee } from "./Assignee";
 import type { Recorded } from "./Recorded";
 import type { Resolution } from "./Resolution";
 import type { WorkDuration } from "./WorkDuration";
@@ -8,13 +8,13 @@ import type { WorkDuration } from "./WorkDuration";
  * 対応記録
  *
  * 相談に対して行った対応の記録。
- * 担当メンバー・解決ステータスは過去データで未記録の場合がある。
+ * 過去データでは各フィールドが未記録の場合がある。
  */
 export type SupportRecord = {
-	/** 担当メンバーID一覧 */
-	readonly assignedMemberIds: Recorded<NonEmptyArray<MemberId>>;
+	/** 対応者一覧 */
+	readonly assignees: Recorded<NonEmptyArray<Assignee>>;
 	/** 対応内容 */
-	readonly content: string;
+	readonly content: Recorded<string>;
 	/** 解決ステータス */
 	readonly resolution: Recorded<Resolution>;
 	/** 作業時間 */

--- a/src/domain/aggregates/karte/index.ts
+++ b/src/domain/aggregates/karte/index.ts
@@ -1,3 +1,4 @@
+export * from "./Assignee";
 export * from "./Karte";
 export * from "./KarteId";
 export * from "./KarteRepository";

--- a/src/domain/shared/affiliation/Affiliation.ts
+++ b/src/domain/shared/affiliation/Affiliation.ts
@@ -1,10 +1,18 @@
 import { ValueObject } from "#domain/base/ValueObject";
 import type {
+	PartialDoctoralAffiliationValue,
+	PartialMasterAffiliationValue,
+	PartialProfessionalAffiliationValue,
+	PartialUndergraduateAffiliationValue,
+} from "./partialUniversityStructure";
+import type {
 	DoctoralAffiliationValue,
 	MasterAffiliationValue,
 	ProfessionalAffiliationValue,
 	UndergraduateAffiliationValue,
 } from "./universityStructure";
+
+// ── 完全な所属（全フィールド既知） ──
 
 /** 学部所属 */
 export class UndergraduateAffiliation extends ValueObject<UndergraduateAffiliationValue> {
@@ -26,9 +34,38 @@ export class ProfessionalAffiliation extends ValueObject<ProfessionalAffiliation
 	protected validate(): void {}
 }
 
-/** 所属 — 学生が大学組織のどこに在籍しているかを表す */
+/** 完全な所属 — 全フィールドが既知 */
 export type Affiliation =
-	| UndergraduateAffiliation // 学部
-	| MasterAffiliation // 修士
-	| DoctoralAffiliation // 博士
-	| ProfessionalAffiliation; // 専門職
+	| UndergraduateAffiliation
+	| MasterAffiliation
+	| DoctoralAffiliation
+	| ProfessionalAffiliation;
+
+// ── 部分的な所属（下位フィールドが欠損しうる） ──
+
+/** 部分的な学部所属 */
+export class PartialUndergraduateAffiliation extends ValueObject<PartialUndergraduateAffiliationValue> {
+	protected validate(): void {}
+}
+
+/** 部分的な修士課程所属 */
+export class PartialMasterAffiliation extends ValueObject<PartialMasterAffiliationValue> {
+	protected validate(): void {}
+}
+
+/** 部分的な博士課程所属 */
+export class PartialDoctoralAffiliation extends ValueObject<PartialDoctoralAffiliationValue> {
+	protected validate(): void {}
+}
+
+/** 部分的な専門職学位課程所属 */
+export class PartialProfessionalAffiliation extends ValueObject<PartialProfessionalAffiliationValue> {
+	protected validate(): void {}
+}
+
+/** 部分的な所属 — 階層の途中までしかわからない */
+export type PartialAffiliation =
+	| PartialUndergraduateAffiliation
+	| PartialMasterAffiliation
+	| PartialDoctoralAffiliation
+	| PartialProfessionalAffiliation;

--- a/src/domain/shared/affiliation/index.ts
+++ b/src/domain/shared/affiliation/index.ts
@@ -1,2 +1,3 @@
 export * from "./Affiliation";
+export * from "./partialUniversityStructure";
 export * from "./universityStructure";

--- a/src/domain/shared/affiliation/partialUniversityStructure.ts
+++ b/src/domain/shared/affiliation/partialUniversityStructure.ts
@@ -1,0 +1,288 @@
+/**
+ * 部分的な所属情報の型定義
+ *
+ * 過去データのインポート時など、所属情報が不完全な場合に使用する。
+ * 階層構造のリテラル型制約を維持しつつ、下位フィールドの欠損を許容する。
+ * 最小単位は学部/研究科名のみ。それ未満は notRecorded() で表現する。
+ */
+
+import type {
+	AgricultureFacultyValue,
+	CreativeSciTechDoctoralValue,
+	EducationDoctoralValue,
+	EducationFacultyValue,
+	EngineeringFacultyValue,
+	GlobalCoCreationFacultyValue,
+	HumanitiesFacultyValue,
+	HumanitiesMasterValue,
+	InformaticsFacultyValue,
+	IntegratedSciTechMasterValue,
+	MountainWatershedValue,
+	OptoBiomedicalDoctoralValue,
+	ProfessionalAffiliationValue,
+	RegionalDevelopmentValue,
+	ScienceFacultyValue,
+} from "./universityStructure";
+
+// ── 学部（Undergraduate）部分型 ──
+
+export type PartialHumanitiesFacultyValue =
+	| HumanitiesFacultyValue
+	| {
+			faculty: "人文社会科学部";
+			enrollmentType: "昼間コース";
+			department: "社会学科" | "言語文化学科" | "法学科" | "経済学科";
+	  }
+	| {
+			faculty: "人文社会科学部";
+			enrollmentType: "夜間主コース";
+			department: "法学科" | "経済学科";
+	  }
+	| { faculty: "人文社会科学部"; enrollmentType: "昼間コース" | "夜間主コース" }
+	| { faculty: "人文社会科学部" };
+
+export type PartialEducationFacultyValue =
+	| EducationFacultyValue
+	| {
+			faculty: "教育学部";
+			program: "学校教育教員養成課程";
+			major: "発達教育学専攻";
+			subspecialty: "教育実践学専修" | "教育心理学専修" | "幼児教育専修";
+	  }
+	| {
+			faculty: "教育学部";
+			program: "学校教育教員養成課程";
+			major: "教科教育学専攻";
+			subspecialty:
+				| "国語教育専修"
+				| "社会科教育専修"
+				| "数学教育専修"
+				| "理科教育専修"
+				| "音楽教育専修"
+				| "美術教育専修"
+				| "保健体育教育専修"
+				| "技術教育専修"
+				| "家庭科教育専修"
+				| "英語教育専修";
+	  }
+	| {
+			faculty: "教育学部";
+			program: "学校教育教員養成課程";
+			major:
+				| "発達教育学専攻"
+				| "初等学習開発学専攻"
+				| "養護教育専攻"
+				| "特別支援教育専攻"
+				| "教科教育学専攻";
+	  }
+	| { faculty: "教育学部"; program: "学校教育教員養成課程" }
+	| { faculty: "教育学部" };
+
+export type PartialInformaticsFacultyValue =
+	| InformaticsFacultyValue
+	| {
+			faculty: "情報学部";
+			department: "情報科学科" | "行動情報学科" | "情報社会学科";
+	  }
+	| { faculty: "情報学部" };
+
+export type PartialScienceFacultyValue =
+	| ScienceFacultyValue
+	| {
+			faculty: "理学部";
+			department: "数学科" | "物理学科" | "化学科" | "生物科学科" | "地球科学科";
+	  }
+	| { faculty: "理学部"; course: "創造理学コース" }
+	| { faculty: "理学部" };
+
+export type PartialEngineeringFacultyValue =
+	| EngineeringFacultyValue
+	| {
+			faculty: "工学部";
+			department: "機械工学科";
+			course:
+				| "宇宙・環境コース"
+				| "知能・材料コース"
+				| "電気機械システムコース";
+	  }
+	| {
+			faculty: "工学部";
+			department: "電気電子工学科";
+			course: "情報エレクトロニクスコース" | "エネルギー・電子制御コース";
+	  }
+	| {
+			faculty: "工学部";
+			department: "電子物質科学科";
+			course: "電子物理デバイスコース" | "材料エネルギー化学コース";
+	  }
+	| {
+			faculty: "工学部";
+			department: "化学バイオ工学科";
+			course: "環境応用化学コース" | "バイオ応用工学コース";
+	  }
+	| {
+			faculty: "工学部";
+			department:
+				| "機械工学科"
+				| "電気電子工学科"
+				| "電子物質科学科"
+				| "化学バイオ工学科"
+				| "数理システム工学科";
+	  }
+	| { faculty: "工学部" };
+
+export type PartialAgricultureFacultyValue =
+	| AgricultureFacultyValue
+	| {
+			faculty: "農学部";
+			department: "生物資源科学科";
+			course: "バイオサイエンスコース" | "環境サイエンスコース";
+	  }
+	| {
+			faculty: "農学部";
+			department: "生物資源科学科" | "応用生命科学科";
+	  }
+	| { faculty: "農学部" };
+
+export type PartialGlobalCoCreationFacultyValue =
+	| GlobalCoCreationFacultyValue
+	| {
+			faculty: "グローバル共創科学部";
+			department: "グローバル共創科学科";
+			course:
+				| "国際地域共生学コース"
+				| "生命圏循環共生学コース"
+				| "総合人間科学コース";
+	  }
+	| {
+			faculty: "グローバル共創科学部";
+			department: "グローバル共創科学科";
+	  }
+	| { faculty: "グローバル共創科学部" };
+
+export type PartialRegionalDevelopmentValue =
+	| RegionalDevelopmentValue
+	| { faculty: "地域創造学環" };
+
+export type PartialUndergraduateAffiliationValue =
+	| PartialHumanitiesFacultyValue
+	| PartialEducationFacultyValue
+	| PartialInformaticsFacultyValue
+	| PartialScienceFacultyValue
+	| PartialEngineeringFacultyValue
+	| PartialAgricultureFacultyValue
+	| PartialGlobalCoCreationFacultyValue
+	| PartialRegionalDevelopmentValue;
+
+// ── 修士課程（Master）部分型 ──
+
+export type PartialHumanitiesMasterValue =
+	| HumanitiesMasterValue
+	| {
+			school: "人文社会科学研究科";
+			major: "臨床人間科学専攻";
+			course: "臨床心理学コース" | "臨床人間科学コース";
+	  }
+	| {
+			school: "人文社会科学研究科";
+			major: "比較地域文化専攻";
+			course: "歴史・文化論コース" | "言語文化論コース";
+	  }
+	| {
+			school: "人文社会科学研究科";
+			major: "経済専攻";
+			course: "国際経営コース" | "地域公共政策コース";
+	  }
+	| {
+			school: "人文社会科学研究科";
+			major: "臨床人間科学専攻" | "比較地域文化専攻" | "経済専攻";
+	  }
+	| { school: "人文社会科学研究科" };
+
+export type PartialIntegratedSciTechMasterValue =
+	| IntegratedSciTechMasterValue
+	| {
+			school: "総合科学技術研究科";
+			major: "情報学専攻";
+			course: "基盤情報学コース" | "領域情報学コース";
+	  }
+	| {
+			school: "総合科学技術研究科";
+			major: "理学専攻";
+			course:
+				| "数学コース"
+				| "物理学コース"
+				| "化学コース"
+				| "生物科学コース"
+				| "地球科学コース";
+	  }
+	| {
+			school: "総合科学技術研究科";
+			major: "工学専攻";
+			course:
+				| "機械工学コース"
+				| "電気電子工学コース"
+				| "電子物質科学コース"
+				| "化学バイオ工学コース"
+				| "数理システム工学コース"
+				| "事業開発マネジメントコース";
+	  }
+	| {
+			school: "総合科学技術研究科";
+			major: "農学専攻";
+			course:
+				| "生物資源科学コース"
+				| "応用生命科学コース"
+				| "環境森林科学コース";
+	  }
+	| {
+			school: "総合科学技術研究科";
+			major: "情報学専攻" | "理学専攻" | "工学専攻" | "農学専攻";
+	  }
+	| { school: "総合科学技術研究科" };
+
+export type PartialMountainWatershedValue =
+	| MountainWatershedValue
+	| { school: "山岳流域研究院" };
+
+export type PartialMasterAffiliationValue =
+	| PartialHumanitiesMasterValue
+	| PartialIntegratedSciTechMasterValue
+	| PartialMountainWatershedValue;
+
+// ── 博士課程（Doctoral）部分型 ──
+
+export type PartialCreativeSciTechDoctoralValue =
+	| CreativeSciTechDoctoralValue
+	| {
+			school: "創造科学技術大学院";
+			major:
+				| "ナノビジョン工学専攻"
+				| "光・ナノ物質機能専攻"
+				| "情報科学専攻"
+				| "環境・エネルギーシステム専攻"
+				| "バイオサイエンス専攻";
+	  }
+	| { school: "創造科学技術大学院" };
+
+export type PartialEducationDoctoralValue =
+	| EducationDoctoralValue
+	| { school: "教育学研究科"; major: "共同教科開発学専攻" }
+	| { school: "教育学研究科" };
+
+export type PartialOptoBiomedicalDoctoralValue =
+	| OptoBiomedicalDoctoralValue
+	| { school: "光医工学研究科"; major: "光医工学共同専攻" }
+	| { school: "光医工学研究科" };
+
+export type PartialDoctoralAffiliationValue =
+	| PartialCreativeSciTechDoctoralValue
+	| PartialEducationDoctoralValue
+	| PartialOptoBiomedicalDoctoralValue;
+
+// ── 専門職学位課程（Professional）部分型 ──
+
+export type PartialProfessionalAffiliationValue =
+	| ProfessionalAffiliationValue
+	| { school: "教育学研究科"; major: "教育実践高度化専攻" }
+	| { school: "教育学研究科" };

--- a/src/executable/index.ts
+++ b/src/executable/index.ts
@@ -1,2 +1,3 @@
 export * from "./member";
 export * from "./event";
+export * from "./karte";

--- a/src/executable/karte.ts
+++ b/src/executable/karte.ts
@@ -1,0 +1,28 @@
+import {
+	CreateKarteUseCase,
+	CorrectKarteUseCase,
+	GetKarteUseCase,
+	ImportKarteUseCase,
+	ListKartesUseCase,
+} from "#application";
+import { DrizzleKarteRepository } from "#infrastructure";
+
+export type KarteUseCases = {
+	createKarte: CreateKarteUseCase;
+	correctKarte: CorrectKarteUseCase;
+	getKarte: GetKarteUseCase;
+	importKarte: ImportKarteUseCase;
+	listKartes: ListKartesUseCase;
+};
+
+export function createKarteUseCases(): KarteUseCases {
+	const karteRepo = new DrizzleKarteRepository();
+
+	return {
+		createKarte: new CreateKarteUseCase(karteRepo),
+		correctKarte: new CorrectKarteUseCase(karteRepo),
+		getKarte: new GetKarteUseCase(karteRepo),
+		importKarte: new ImportKarteUseCase(karteRepo),
+		listKartes: new ListKartesUseCase(karteRepo),
+	};
+}

--- a/src/infrastructure/drizzle/DrizzleKarteRepository.ts
+++ b/src/infrastructure/drizzle/DrizzleKarteRepository.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import type { Assignee } from "#domain/aggregates/karte/Assignee";
 import type { Client } from "#domain/aggregates/karte/Client";
 import type { Consultation } from "#domain/aggregates/karte/Consultation";
 import type { ConsultationCategory } from "#domain/aggregates/karte/ConsultationCategory";
@@ -10,12 +11,17 @@ import { notRecorded, recorded } from "#domain/aggregates/karte/Recorded";
 import type { Resolution } from "#domain/aggregates/karte/Resolution";
 import type { SupportRecord } from "#domain/aggregates/karte/SupportRecord";
 import { workDuration } from "#domain/aggregates/karte/WorkDuration";
-import { type MemberId, memberId } from "#domain/aggregates/member/MemberId";
+import { memberId } from "#domain/aggregates/member/MemberId";
 import type { NonEmptyArray } from "#domain/base/NonEmptyArray";
 import {
 	type Affiliation,
 	DoctoralAffiliation,
 	MasterAffiliation,
+	type PartialAffiliation,
+	PartialDoctoralAffiliation,
+	PartialMasterAffiliation,
+	PartialProfessionalAffiliation,
+	PartialUndergraduateAffiliation,
 	ProfessionalAffiliation,
 	StudentId,
 	UndergraduateAffiliation,
@@ -24,7 +30,7 @@ import { getDb } from "./client";
 import type { SerializedAffiliation } from "./schema";
 import {
 	consultationCategories,
-	karteAssignedMembers,
+	karteAssignees,
 	karteConsultationCategories,
 	kartes,
 } from "./schema";
@@ -39,7 +45,7 @@ type KarteWithRelations = KarteRow & {
 	karteConsultationCategories: (typeof karteConsultationCategories.$inferSelect & {
 		category: typeof consultationCategories.$inferSelect;
 	})[];
-	karteAssignedMembers: (typeof karteAssignedMembers.$inferSelect)[];
+	karteAssignees: (typeof karteAssignees.$inferSelect)[];
 };
 
 // ============================================================================
@@ -79,30 +85,62 @@ function toRecordedClient(row: KarteRow): Recorded<Client> {
 	}
 }
 
-function deserializeAffiliation(json: SerializedAffiliation): Affiliation {
+/**
+ * JSONBからAffiliationを復元する。
+ *
+ * yearフィールドの有無で完全/部分を判別する。
+ * DB由来のJSONBデータのため、キャストで型を絞り込む。
+ */
+function deserializeAffiliation(
+	json: SerializedAffiliation,
+): Affiliation | PartialAffiliation {
+	const hasYear = "year" in json.value;
+
 	switch (json.type) {
 		case "undergraduate":
-			return new UndergraduateAffiliation(json.value);
+			return hasYear
+				? new UndergraduateAffiliation(json.value as never)
+				: new PartialUndergraduateAffiliation(json.value as never);
 		case "master":
-			return new MasterAffiliation(json.value);
+			return hasYear
+				? new MasterAffiliation(json.value as never)
+				: new PartialMasterAffiliation(json.value as never);
 		case "doctoral":
-			return new DoctoralAffiliation(json.value);
+			return hasYear
+				? new DoctoralAffiliation(json.value as never)
+				: new PartialDoctoralAffiliation(json.value as never);
 		case "professional":
-			return new ProfessionalAffiliation(json.value);
+			return hasYear
+				? new ProfessionalAffiliation(json.value as never)
+				: new PartialProfessionalAffiliation(json.value as never);
 	}
 }
 
-function serializeAffiliation(affiliation: Affiliation): SerializedAffiliation {
-	if (affiliation instanceof UndergraduateAffiliation) {
+function serializeAffiliation(
+	affiliation: Affiliation | PartialAffiliation,
+): SerializedAffiliation {
+	if (
+		affiliation instanceof UndergraduateAffiliation ||
+		affiliation instanceof PartialUndergraduateAffiliation
+	) {
 		return { type: "undergraduate", value: affiliation.getValue() };
 	}
-	if (affiliation instanceof MasterAffiliation) {
+	if (
+		affiliation instanceof MasterAffiliation ||
+		affiliation instanceof PartialMasterAffiliation
+	) {
 		return { type: "master", value: affiliation.getValue() };
 	}
-	if (affiliation instanceof DoctoralAffiliation) {
+	if (
+		affiliation instanceof DoctoralAffiliation ||
+		affiliation instanceof PartialDoctoralAffiliation
+	) {
 		return { type: "doctoral", value: affiliation.getValue() };
 	}
-	if (affiliation instanceof ProfessionalAffiliation) {
+	if (
+		affiliation instanceof ProfessionalAffiliation ||
+		affiliation instanceof PartialProfessionalAffiliation
+	) {
 		return { type: "professional", value: affiliation.getValue() };
 	}
 	const _: never = affiliation;
@@ -136,7 +174,8 @@ function toConsultation(row: KarteWithRelations): Consultation {
 				: notRecorded(),
 		targetDevice:
 			row.targetDevice !== null ? recorded(row.targetDevice) : notRecorded(),
-		troubleDetails: row.troubleDetails,
+		troubleDetails:
+			row.troubleDetails !== null ? recorded(row.troubleDetails) : notRecorded(),
 	};
 }
 
@@ -155,17 +194,29 @@ function toResolution(row: KarteRow): Recorded<Resolution> {
 	}
 }
 
+function toAssignee(
+	row: typeof karteAssignees.$inferSelect,
+): Assignee {
+	if (row.assigneeType === "resolved") {
+		if (row.memberId === null) {
+			throw new Error("データ不整合: assigneeType=resolved だが memberId が null");
+		}
+		return { type: "resolved", memberId: memberId(row.memberId) };
+	}
+	if (row.assigneeName === null) {
+		throw new Error("データ不整合: assigneeType=unresolved だが assigneeName が null");
+	}
+	return { type: "unresolved", name: row.assigneeName };
+}
+
 function toSupportRecord(row: KarteWithRelations): SupportRecord {
 	return {
-		assignedMemberIds:
-			row.karteAssignedMembers.length > 0
-				? recorded(
-						toNonEmptyArray(
-							row.karteAssignedMembers.map((kam) => memberId(kam.memberId)),
-						),
-					)
+		assignees:
+			row.karteAssignees.length > 0
+				? recorded(toNonEmptyArray(row.karteAssignees.map(toAssignee)))
 				: notRecorded(),
-		content: row.supportContent,
+		content:
+			row.supportContent !== null ? recorded(row.supportContent) : notRecorded(),
 		resolution: toResolution(row),
 		workDuration:
 			row.workDurationMinutes !== null
@@ -256,12 +307,26 @@ export class DrizzleKarteRepository implements KarteRepository {
 				karteConsultationCategories: {
 					with: { category: true },
 				},
-				karteAssignedMembers: true,
+				karteAssignees: true,
 			},
 		});
 
 		if (!row) return null;
 		return toDomain(row);
+	}
+
+	async findAll(): Promise<Karte[]> {
+		const db = getDb();
+		const rows = await db.query.kartes.findMany({
+			with: {
+				karteConsultationCategories: {
+					with: { category: true },
+				},
+				karteAssignees: true,
+			},
+			orderBy: (kartes, { desc }) => [desc(kartes.recordedAt)],
+		});
+		return rows.map(toDomain);
 	}
 
 	async save(karte: Karte): Promise<void> {
@@ -282,9 +347,9 @@ export class DrizzleKarteRepository implements KarteRepository {
 			clientAffiliation: clientCols.clientAffiliation,
 			liabilityConsent: karte.consent.liabilityConsent,
 			disclosureConsent: karte.consent.disclosureConsent,
-			troubleDetails: karte.consultation.troubleDetails,
+			troubleDetails: recordedToNullable(karte.consultation.troubleDetails),
 			targetDevice: recordedToNullable(karte.consultation.targetDevice),
-			supportContent: karte.supportRecord.content,
+			supportContent: recordedToNullable(karte.supportRecord.content),
 			resolutionType: resCols.resolutionType,
 			followUp: resCols.followUp,
 			workDurationMinutes: recordedToNullable(karte.supportRecord.workDuration),
@@ -306,7 +371,6 @@ export class DrizzleKarteRepository implements KarteRepository {
 
 		if (karte.consultation.categories.type === "recorded") {
 			for (const cat of karte.consultation.categories.value) {
-				// Ensure category master exists
 				await db
 					.insert(consultationCategories)
 					.values({
@@ -326,16 +390,22 @@ export class DrizzleKarteRepository implements KarteRepository {
 			}
 		}
 
-		// Sync assigned members (delete-all-then-insert)
+		// Sync assignees (delete-all-then-insert)
 		await db
-			.delete(karteAssignedMembers)
-			.where(eq(karteAssignedMembers.karteId, karte.id as string));
+			.delete(karteAssignees)
+			.where(eq(karteAssignees.karteId, karte.id as string));
 
-		if (karte.supportRecord.assignedMemberIds.type === "recorded") {
-			for (const mid of karte.supportRecord.assignedMemberIds.value) {
-				await db.insert(karteAssignedMembers).values({
+		if (karte.supportRecord.assignees.type === "recorded") {
+			for (const assignee of karte.supportRecord.assignees.value) {
+				await db.insert(karteAssignees).values({
 					karteId: karte.id as string,
-					memberId: mid as string,
+					assigneeType: assignee.type,
+					memberId:
+						assignee.type === "resolved"
+							? (assignee.memberId as string)
+							: null,
+					assigneeName:
+						assignee.type === "unresolved" ? assignee.name : null,
 				});
 			}
 		}

--- a/src/infrastructure/drizzle/schema.ts
+++ b/src/infrastructure/drizzle/schema.ts
@@ -15,6 +15,12 @@ import {
 	varchar,
 } from "drizzle-orm/pg-core";
 import type {
+	PartialDoctoralAffiliationValue,
+	PartialMasterAffiliationValue,
+	PartialProfessionalAffiliationValue,
+	PartialUndergraduateAffiliationValue,
+} from "#domain/shared/affiliation/partialUniversityStructure";
+import type {
 	DoctoralAffiliationValue,
 	MasterAffiliationValue,
 	ProfessionalAffiliationValue,
@@ -228,10 +234,10 @@ export const followUpEnum = pgEnum("follow_up", [
 
 /** Affiliationのシリアライズ形式 — ドメインの値型で判別共用体にする */
 export type SerializedAffiliation =
-	| { type: "undergraduate"; value: UndergraduateAffiliationValue }
-	| { type: "master"; value: MasterAffiliationValue }
-	| { type: "doctoral"; value: DoctoralAffiliationValue }
-	| { type: "professional"; value: ProfessionalAffiliationValue };
+	| { type: "undergraduate"; value: UndergraduateAffiliationValue | PartialUndergraduateAffiliationValue }
+	| { type: "master"; value: MasterAffiliationValue | PartialMasterAffiliationValue }
+	| { type: "doctoral"; value: DoctoralAffiliationValue | PartialDoctoralAffiliationValue }
+	| { type: "professional"; value: ProfessionalAffiliationValue | PartialProfessionalAffiliationValue };
 
 export const kartes = pgTable("kartes", {
 	id: text().primaryKey(),
@@ -249,10 +255,12 @@ export const kartes = pgTable("kartes", {
 	clientAffiliation: jsonb("client_affiliation").$type<SerializedAffiliation>(),
 	liabilityConsent: boolean("liability_consent").notNull(),
 	disclosureConsent: boolean("disclosure_consent").notNull(),
-	troubleDetails: text("trouble_details").notNull(),
+	/** NULL = notRecorded */
+	troubleDetails: text("trouble_details"),
 	/** NULL = notRecorded */
 	targetDevice: text("target_device"),
-	supportContent: text("support_content").notNull(),
+	/** NULL = notRecorded */
+	supportContent: text("support_content"),
 	/** NULL = notRecorded */
 	resolutionType: resolutionTypeEnum("resolution_type"),
 	/** Only for unresolved; NULL = notRecorded or N/A */
@@ -296,28 +304,33 @@ export const karteConsultationCategories = pgTable(
 	],
 );
 
-export const karteAssignedMembers = pgTable(
-	"karte_assigned_members",
+export const assigneeTypeEnum = pgEnum("assignee_type", [
+	"resolved",
+	"unresolved",
+]);
+
+export const karteAssignees = pgTable(
+	"karte_assignees",
 	{
 		karteId: text("karte_id").notNull(),
-		memberId: text("member_id").notNull(),
+		assigneeType: assigneeTypeEnum("assignee_type").notNull(),
+		/** resolved の場合のみ。メンバーID */
+		memberId: text("member_id"),
+		/** unresolved の場合のみ。対応者名 */
+		assigneeName: text("assignee_name"),
 	},
 	(table) => [
-		primaryKey({
-			columns: [table.karteId, table.memberId],
-			name: "karte_assigned_members_pkey",
-		}),
 		foreignKey({
 			columns: [table.karteId],
 			foreignColumns: [kartes.id],
-			name: "karte_assigned_members_karte_id_fkey",
+			name: "karte_assignees_karte_id_fkey",
 		})
 			.onUpdate("cascade")
 			.onDelete("cascade"),
 		foreignKey({
 			columns: [table.memberId],
 			foreignColumns: [members.id],
-			name: "karte_assigned_members_member_id_fkey",
+			name: "karte_assignees_member_id_fkey",
 		})
 			.onUpdate("cascade")
 			.onDelete("restrict"),
@@ -412,7 +425,7 @@ export const memberExhibitsRelations = relations(memberExhibits, ({ one }) => ({
 
 export const kartesRelations = relations(kartes, ({ many }) => ({
 	karteConsultationCategories: many(karteConsultationCategories),
-	karteAssignedMembers: many(karteAssignedMembers),
+	karteAssignees: many(karteAssignees),
 }));
 
 export const consultationCategoriesRelations = relations(
@@ -436,15 +449,15 @@ export const karteConsultationCategoriesRelations = relations(
 	}),
 );
 
-export const karteAssignedMembersRelations = relations(
-	karteAssignedMembers,
+export const karteAssigneesRelations = relations(
+	karteAssignees,
 	({ one }) => ({
 		karte: one(kartes, {
-			fields: [karteAssignedMembers.karteId],
+			fields: [karteAssignees.karteId],
 			references: [kartes.id],
 		}),
 		member: one(members, {
-			fields: [karteAssignedMembers.memberId],
+			fields: [karteAssignees.memberId],
 			references: [members.id],
 		}),
 	}),

--- a/tests/domain/aggregates/karte/Karte.test.ts
+++ b/tests/domain/aggregates/karte/Karte.test.ts
@@ -83,16 +83,16 @@ describe("Karte", () => {
 
 			expect(karte.consultation.categories.type).toBe("recorded");
 			expect(karte.consultation.targetDevice.type).toBe("recorded");
-			expect(karte.consultation.troubleDetails).toBe("eduroamに接続できない");
+			expect(karte.consultation.troubleDetails.type).toBe("recorded");
 		});
 
 		it("supportRecord内のフィールドがRecordedでラップされる", () => {
 			const karte = Karte.create(createProps());
 
-			expect(karte.supportRecord.assignedMemberIds.type).toBe("recorded");
+			expect(karte.supportRecord.assignees.type).toBe("recorded");
 			expect(karte.supportRecord.resolution.type).toBe("recorded");
 			expect(karte.supportRecord.workDuration.type).toBe("recorded");
-			expect(karte.supportRecord.content).toBe("プロファイルを再設定して解決");
+			expect(karte.supportRecord.content.type).toBe("recorded");
 		});
 	});
 
@@ -131,9 +131,10 @@ describe("Karte", () => {
 				},
 			});
 
-			expect(corrected.consultation.troubleDetails).toBe(
-				"訂正: 実はVPN接続の問題だった",
-			);
+			expect(corrected.consultation.troubleDetails).toEqual({
+				type: "recorded",
+				value: "訂正: 実はVPN接続の問題だった",
+			});
 		});
 
 		it("未解決の場合にfollowUpがRecordedでラップされる", () => {


### PR DESCRIPTION
## Summary
- PartialAffiliation型追加（階層的リテラル型truncation、部分的な所属情報の表現）
- Assignee型追加（resolved: MemberId紐づき / unresolved: 名前のみ）
- SupportRecord.assignedMemberIds → assigneesに変更
- troubleDetails/supportContentをRecorded<string>に変更（過去データの欠損対応）
- ImportKarte/ListKartesユースケース追加
- createKarteUseCases()ファクトリ追加
- DBスキーマ: karte_assigneesテーブル、nullable化
- DrizzleKarteRepository: PartialAffiliation・Assigneeのシリアライズ対応

## Test plan
- [x] 既存テスト全35件通過
- [ ] its-karteからのインポート動作確認
- [ ] db:push後のスキーマ整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)