### PR TITLE
feat: ドメインイベントの監査ログ永続化

### DIFF
--- a/src/domain/aggregates/member/Member.ts
+++ b/src/domain/aggregates/member/Member.ts
@@ -16,15 +16,15 @@ import {
 	InternallyAdvanced,
 	MajorTransferred,
 	MemberConfirmed,
-	MemberRegistered,
 	MemberDeregistered,
+	MemberRegistered,
 	MemberReregistered,
 	MemberUnconfirmed,
 	NameChanged,
 	PersonalEmailChanged,
 	StudentIdChanged,
 } from "./MemberEvent";
-import type { MemberDomainEvent, DeregistrationReason } from "./MemberEvent";
+import type { DeregistrationReason, MemberDomainEvent } from "./MemberEvent";
 import type { MemberId } from "./MemberId";
 import type { UniversityEmail } from "./UniversityEmail";
 


### PR DESCRIPTION
## Why

ドメインイベントは集約のメソッドで蓄積されるが、永続化されておらずメモリ上で消失していた。
監査ログとして変更履歴を追跡可能にするため、イベントの永続化基盤を導入する。

## What

- `member_domain_events` / `discord_account_domain_events` テーブルを追加
- 共通カラム（member_id, email, event_name, occurred_at）+ 型安全なJSONBペイロード
- リポジトリの `save()` 内で同一トランザクションにてイベントを書き込み
- シリアライズ関数を別ファイルに切り出しテスト可能に
- 全12種のMemberイベント・1種のDiscordAccountイベントのシリアライズテスト

## How

- `SerializedMemberEventPayload` / `SerializedDiscordAccountEventPayload` をdiscriminated unionで定義
- Drizzleの `.$type<>()` でJSONBカラムにコンパイル時型安全性を付与
- 追記専用（UPDATE/DELETE不要）の監査ログ設計

🤖 Generated with [Claude Code](https://claude.com/claude-code)