### PR TITLE
refactor: Affiliationの型表現をDiscriminated Unionに変更

### DIFF
--- a/scripts/list-members.ts
+++ b/scripts/list-members.ts
@@ -5,11 +5,11 @@
  *   DATABASE_URL="postgresql://..." npx tsx scripts/list-members.ts
  */
 
-import {
-	type ActiveMember,
-	type FormerMember,
-	type Member,
-	type UnconfirmedMember,
+import type {
+	ActiveMember,
+	FormerMember,
+	Member,
+	UnconfirmedMember,
 } from "#domain/aggregates/member";
 import {
 	DoctoralAffiliation,
@@ -64,9 +64,15 @@ async function main() {
 
 	console.log(`全メンバー: ${members.length}件\n`);
 
-	const active = members.filter((m): m is ActiveMember => m.status === "active");
-	const unconfirmed = members.filter((m): m is UnconfirmedMember => m.status === "unconfirmed");
-	const former = members.filter((m): m is FormerMember => m.status === "former");
+	const active = members.filter(
+		(m): m is ActiveMember => m.status === "active",
+	);
+	const unconfirmed = members.filter(
+		(m): m is UnconfirmedMember => m.status === "unconfirmed",
+	);
+	const former = members.filter(
+		(m): m is FormerMember => m.status === "former",
+	);
 
 	console.log(`=== 室員 (active): ${active.length}件 ===`);
 	for (const m of active) {

--- a/scripts/migrate-members.ts
+++ b/scripts/migrate-members.ts
@@ -232,7 +232,12 @@ function migrateRow(row: MemberRow): {
 	}
 
 	if (mapping.status === "former") {
-		return { status: "former", affiliation: null, skipped: false, deleted: false };
+		return {
+			status: "former",
+			affiliation: null,
+			skipped: false,
+			deleted: false,
+		};
 	}
 
 	const enrollmentYear = extractEnrollmentYear(row.email);
@@ -257,7 +262,12 @@ function migrateRow(row: MemberRow): {
 		};
 	}
 
-	return { status: mapping.status, affiliation, skipped: false, deleted: false };
+	return {
+		status: mapping.status,
+		affiliation,
+		skipped: false,
+		deleted: false,
+	};
 }
 
 // ============================================================================

--- a/src/domain/aggregates/member/Member.ts
+++ b/src/domain/aggregates/member/Member.ts
@@ -1,13 +1,13 @@
 import { InvalidAffiliationOperationException } from "#domain/exceptions";
 import type { Recorded } from "#domain/shared/Recorded";
-import { notRecorded, recorded } from "#domain/shared/Recorded";
 import type { StudentId } from "#domain/shared/StudentId";
-import type { Affiliation } from "#domain/shared/affiliation/Affiliation";
 import {
-	DoctoralAffiliation,
-	MasterAffiliation,
-	ProfessionalAffiliation,
-	UndergraduateAffiliation,
+	type Affiliation,
+	type DoctoralAffiliation,
+	type MasterAffiliation,
+	type ProfessionalAffiliation,
+	type UndergraduateAffiliation,
+	affiliationTypeNames,
 } from "#domain/shared/affiliation/Affiliation";
 import type { Email } from "./Email";
 import {
@@ -202,10 +202,10 @@ export class ActiveMember {
 	}
 
 	transferFaculty(newAffiliation: UndergraduateAffiliation): ActiveMember {
-		if (!(this.affiliation instanceof UndergraduateAffiliation)) {
+		if (this.affiliation.type !== "undergraduate") {
 			throw new InvalidAffiliationOperationException(
 				"転学部",
-				this.affiliationTypeName(),
+				affiliationTypeNames[this.affiliation.type],
 				"学部生のみ可能です",
 			);
 		}
@@ -231,21 +231,19 @@ export class ActiveMember {
 	}
 
 	transferDepartment(newAffiliation: UndergraduateAffiliation): ActiveMember {
-		if (!(this.affiliation instanceof UndergraduateAffiliation)) {
+		if (this.affiliation.type !== "undergraduate") {
 			throw new InvalidAffiliationOperationException(
 				"転学科",
-				this.affiliationTypeName(),
+				affiliationTypeNames[this.affiliation.type],
 				"学部生のみ可能です",
 			);
 		}
 
-		if (
-			this.affiliation.getValue().faculty !== newAffiliation.getValue().faculty
-		) {
+		if (this.affiliation.value.faculty !== newAffiliation.value.faculty) {
 			throw new InvalidAffiliationOperationException(
 				"転学科",
-				this.affiliationTypeName(),
-				`同一学部内でのみ可能です（現在: ${this.affiliation.getValue().faculty}）`,
+				affiliationTypeNames[this.affiliation.type],
+				`同一学部内でのみ可能です（現在: ${this.affiliation.value.faculty}）`,
 			);
 		}
 
@@ -275,22 +273,19 @@ export class ActiveMember {
 			| DoctoralAffiliation
 			| ProfessionalAffiliation,
 	): ActiveMember {
-		const currentGraduate = this.asGraduateAffiliation();
-		if (!currentGraduate) {
+		if (this.affiliation.type === "undergraduate") {
 			throw new InvalidAffiliationOperationException(
 				"転専攻",
-				this.affiliationTypeName(),
+				affiliationTypeNames[this.affiliation.type],
 				"大学院生のみ可能です",
 			);
 		}
 
-		if (
-			currentGraduate.getValue().school !== newAffiliation.getValue().school
-		) {
+		if (this.affiliation.value.school !== newAffiliation.value.school) {
 			throw new InvalidAffiliationOperationException(
 				"転専攻",
-				this.affiliationTypeName(),
-				`同一研究科内でのみ可能です（現在: ${currentGraduate.getValue().school}）`,
+				affiliationTypeNames[this.affiliation.type],
+				`同一研究科内でのみ可能です（現在: ${this.affiliation.value.school}）`,
 			);
 		}
 
@@ -306,7 +301,7 @@ export class ActiveMember {
 				new MajorTransferred(
 					this.id,
 					this.email,
-					currentGraduate,
+					this.affiliation,
 					newAffiliation,
 					new Date(),
 				),
@@ -321,22 +316,22 @@ export class ActiveMember {
 	private validateAdvancement(
 		newAffiliation: MasterAffiliation | DoctoralAffiliation,
 	): void {
-		if (this.affiliation instanceof UndergraduateAffiliation) {
-			if (!(newAffiliation instanceof MasterAffiliation)) {
+		if (this.affiliation.type === "undergraduate") {
+			if (newAffiliation.type !== "master") {
 				throw new InvalidAffiliationOperationException(
 					"内部進学",
-					this.affiliationTypeName(),
+					affiliationTypeNames[this.affiliation.type],
 					"学部生からは修士課程のみ可能です",
 				);
 			}
 			return;
 		}
 
-		if (this.affiliation instanceof MasterAffiliation) {
-			if (!(newAffiliation instanceof DoctoralAffiliation)) {
+		if (this.affiliation.type === "master") {
+			if (newAffiliation.type !== "doctoral") {
 				throw new InvalidAffiliationOperationException(
 					"内部進学",
-					this.affiliationTypeName(),
+					affiliationTypeNames[this.affiliation.type],
 					"修士からは博士課程のみ可能です",
 				);
 			}
@@ -345,32 +340,9 @@ export class ActiveMember {
 
 		throw new InvalidAffiliationOperationException(
 			"内部進学",
-			this.affiliationTypeName(),
+			affiliationTypeNames[this.affiliation.type],
 			"この課程からの内部進学はできません",
 		);
-	}
-
-	private asGraduateAffiliation():
-		| MasterAffiliation
-		| DoctoralAffiliation
-		| ProfessionalAffiliation
-		| null {
-		if (
-			this.affiliation instanceof MasterAffiliation ||
-			this.affiliation instanceof DoctoralAffiliation ||
-			this.affiliation instanceof ProfessionalAffiliation
-		) {
-			return this.affiliation;
-		}
-		return null;
-	}
-
-	private affiliationTypeName(): string {
-		if (this.affiliation instanceof UndergraduateAffiliation) return "学部";
-		if (this.affiliation instanceof MasterAffiliation) return "修士";
-		if (this.affiliation instanceof DoctoralAffiliation) return "博士";
-		if (this.affiliation instanceof ProfessionalAffiliation) return "専門職";
-		return "不明";
 	}
 }
 

--- a/src/domain/shared/affiliation/Affiliation.ts
+++ b/src/domain/shared/affiliation/Affiliation.ts
@@ -1,4 +1,3 @@
-import { ValueObject } from "#domain/base/ValueObject";
 import type {
 	DoctoralAffiliationValue,
 	MasterAffiliationValue,
@@ -7,28 +6,40 @@ import type {
 } from "./universityStructure";
 
 /** 学部所属 */
-export class UndergraduateAffiliation extends ValueObject<UndergraduateAffiliationValue> {
-	protected validate(): void {}
-}
+export type UndergraduateAffiliation = {
+	readonly type: "undergraduate";
+	readonly value: UndergraduateAffiliationValue;
+};
 
 /** 修士課程所属 */
-export class MasterAffiliation extends ValueObject<MasterAffiliationValue> {
-	protected validate(): void {}
-}
+export type MasterAffiliation = {
+	readonly type: "master";
+	readonly value: MasterAffiliationValue;
+};
 
 /** 博士課程所属 */
-export class DoctoralAffiliation extends ValueObject<DoctoralAffiliationValue> {
-	protected validate(): void {}
-}
+export type DoctoralAffiliation = {
+	readonly type: "doctoral";
+	readonly value: DoctoralAffiliationValue;
+};
 
 /** 専門職学位課程所属 */
-export class ProfessionalAffiliation extends ValueObject<ProfessionalAffiliationValue> {
-	protected validate(): void {}
-}
+export type ProfessionalAffiliation = {
+	readonly type: "professional";
+	readonly value: ProfessionalAffiliationValue;
+};
 
 /** 所属 — 学生が大学組織のどこに在籍しているかを表す */
 export type Affiliation =
-	| UndergraduateAffiliation // 学部
-	| MasterAffiliation // 修士
-	| DoctoralAffiliation // 博士
-	| ProfessionalAffiliation; // 専門職
+	| UndergraduateAffiliation
+	| MasterAffiliation
+	| DoctoralAffiliation
+	| ProfessionalAffiliation;
+
+/** 所属区分の表示名 */
+export const affiliationTypeNames = {
+	undergraduate: "学士",
+	master: "修士",
+	doctoral: "博士",
+	professional: "専門職学位",
+} as const satisfies Record<Affiliation["type"], string>;

--- a/src/infrastructure/drizzle/DrizzleMemberRepository.ts
+++ b/src/infrastructure/drizzle/DrizzleMemberRepository.ts
@@ -11,15 +11,9 @@ import { type MemberId, memberId } from "#domain/aggregates/member/MemberId";
 import { UniversityEmail } from "#domain/aggregates/member/UniversityEmail";
 import { type Recorded, notRecorded, recorded } from "#domain/shared/Recorded";
 import { StudentId } from "#domain/shared/StudentId";
-import {
-	type Affiliation,
-	DoctoralAffiliation,
-	MasterAffiliation,
-	ProfessionalAffiliation,
-	UndergraduateAffiliation,
-} from "#domain/shared/affiliation/Affiliation";
+import type { Affiliation } from "#domain/shared/affiliation/Affiliation";
 import { getDb } from "./client";
-import { type SerializedAffiliation, members } from "./schema";
+import { members } from "./schema";
 
 // ============================================================================
 // Type Definitions
@@ -30,40 +24,6 @@ type MemberRow = typeof members.$inferSelect;
 // ============================================================================
 // Domain ↔ DB Mapping
 // ============================================================================
-
-function deserializeAffiliation(json: SerializedAffiliation): Affiliation {
-	switch (json.type) {
-		case "undergraduate":
-			return new UndergraduateAffiliation(json.value);
-		case "master":
-			return new MasterAffiliation(json.value);
-		case "doctoral":
-			return new DoctoralAffiliation(json.value);
-		case "professional":
-			return new ProfessionalAffiliation(json.value);
-		default: {
-			const _: never = json;
-			throw new Error(`不明なaffiliation type: ${JSON.stringify(_)}`);
-		}
-	}
-}
-
-function serializeAffiliation(affiliation: Affiliation): SerializedAffiliation {
-	if (affiliation instanceof UndergraduateAffiliation) {
-		return { type: "undergraduate", value: affiliation.getValue() };
-	}
-	if (affiliation instanceof MasterAffiliation) {
-		return { type: "master", value: affiliation.getValue() };
-	}
-	if (affiliation instanceof DoctoralAffiliation) {
-		return { type: "doctoral", value: affiliation.getValue() };
-	}
-	if (affiliation instanceof ProfessionalAffiliation) {
-		return { type: "professional", value: affiliation.getValue() };
-	}
-	const _: never = affiliation;
-	throw new Error(`Unknown affiliation type: ${_}`);
-}
 
 function toDomain(row: MemberRow): Member {
 	const id = memberId(row.id);
@@ -87,7 +47,7 @@ function toDomain(row: MemberRow): Member {
 				name,
 				personalEmail,
 				studentId: StudentId.fromString(row.studentId),
-				affiliation: deserializeAffiliation(row.affiliation),
+				affiliation: row.affiliation as Affiliation,
 			});
 		}
 		case "unconfirmed":
@@ -121,7 +81,7 @@ function toInsertValues(member: Member): MemberInsert {
 			return {
 				...base,
 				studentId: member.studentId.getValue(),
-				affiliation: serializeAffiliation(member.affiliation),
+				affiliation: member.affiliation,
 			};
 		case "unconfirmed":
 		case "former":

--- a/src/infrastructure/drizzle/schema.ts
+++ b/src/infrastructure/drizzle/schema.ts
@@ -11,22 +11,7 @@ import {
 	uniqueIndex,
 	varchar,
 } from "drizzle-orm/pg-core";
-import type {
-	DoctoralAffiliationValue,
-	MasterAffiliationValue,
-	ProfessionalAffiliationValue,
-	UndergraduateAffiliationValue,
-} from "#domain/shared/affiliation/universityStructure";
-
-// ============================================================================
-// Serialization Types
-// ============================================================================
-
-export type SerializedAffiliation =
-	| { type: "undergraduate"; value: UndergraduateAffiliationValue }
-	| { type: "master"; value: MasterAffiliationValue }
-	| { type: "doctoral"; value: DoctoralAffiliationValue }
-	| { type: "professional"; value: ProfessionalAffiliationValue };
+import type { Affiliation } from "#domain/shared/affiliation/Affiliation";
 
 // ============================================================================
 // Enums
@@ -51,7 +36,7 @@ export const members = pgTable(
 		email: text().notNull(),
 		personalEmail: text("personal_email"),
 		status: memberStatus().notNull().default("active"),
-		affiliation: jsonb().$type<SerializedAffiliation>(),
+		affiliation: jsonb().$type<Affiliation>(),
 		createdAt: timestamp({ mode: "string" })
 			.default(sql`CURRENT_TIMESTAMP`)
 			.notNull(),

--- a/tests/domain/aggregates/karte/Karte.test.ts
+++ b/tests/domain/aggregates/karte/Karte.test.ts
@@ -4,7 +4,11 @@ import { karteId } from "#domain/aggregates/karte/KarteId";
 import { workDuration } from "#domain/aggregates/karte/WorkDuration";
 import { type MemberId, memberId } from "#domain/aggregates/member/MemberId";
 import { StudentId } from "#domain/shared/StudentId";
-import { UndergraduateAffiliation } from "#domain/shared/affiliation/Affiliation";
+import type { UndergraduateAffiliation } from "#domain/shared/affiliation/Affiliation";
+const testAffiliation: UndergraduateAffiliation = {
+	type: "undergraduate",
+	value: { faculty: "情報学部", department: "情報科学科", year: 3 },
+};
 
 /** テスト用のKarteCreationPropsを生成する */
 function createProps() {
@@ -15,11 +19,7 @@ function createProps() {
 			type: "student" as const,
 			studentId: StudentId.fromString("70312031"),
 			name: "テスト太郎",
-			affiliation: new UndergraduateAffiliation({
-				faculty: "情報学部",
-				department: "情報科学科",
-				year: 3,
-			}),
+			affiliation: testAffiliation,
 		},
 		consent: {
 			liabilityConsent: true,

--- a/tests/domain/aggregates/member/Member.test.ts
+++ b/tests/domain/aggregates/member/Member.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { Email } from "#domain/aggregates/member/Email";
 import {
 	ActiveMember,
 	FormerMember,
@@ -10,7 +9,7 @@ import { UniversityEmail } from "#domain/aggregates/member/UniversityEmail";
 import { InvalidAffiliationOperationException } from "#domain/exceptions";
 import { notRecorded } from "#domain/shared/Recorded";
 import { StudentId } from "#domain/shared/StudentId";
-import {
+import type {
 	DoctoralAffiliation,
 	MasterAffiliation,
 	UndergraduateAffiliation,
@@ -20,37 +19,34 @@ function createEmail() {
 	return new UniversityEmail("test@shizuoka.ac.jp");
 }
 
-function createPersonalEmail() {
-	return new Email("test@example.com");
-}
-
 function createStudentId() {
 	return StudentId.fromString("725A0001");
 }
 
-function createUndergraduateAffiliation() {
-	return new UndergraduateAffiliation({
-		faculty: "情報学部",
-		department: "情報科学科",
-		year: 3,
-	});
+function createUndergraduateAffiliation(): UndergraduateAffiliation {
+	return {
+		type: "undergraduate",
+		value: { faculty: "情報学部", department: "情報科学科", year: 3 },
+	};
 }
 
-function createMasterAffiliation() {
-	return new MasterAffiliation({
-		school: "総合科学技術研究科",
-		major: "情報学専攻",
-		course: "基盤情報学コース",
-		year: 1,
-	});
+function createMasterAffiliation(): MasterAffiliation {
+	return {
+		type: "master",
+		value: {
+			school: "総合科学技術研究科",
+			major: "情報学専攻",
+			course: "基盤情報学コース",
+			year: 1,
+		},
+	};
 }
 
-function createDoctoralAffiliation() {
-	return new DoctoralAffiliation({
-		school: "創造科学技術大学院",
-		major: "情報科学専攻",
-		year: 1,
-	});
+function createDoctoralAffiliation(): DoctoralAffiliation {
+	return {
+		type: "doctoral",
+		value: { school: "創造科学技術大学院", major: "情報科学専攻", year: 1 },
+	};
 }
 
 const TEST_ID = memberId("test-member-id");
@@ -213,7 +209,7 @@ describe("ActiveMember", () => {
 			);
 
 			expect(master.status).toBe("active");
-			expect(master.affiliation).toBeInstanceOf(MasterAffiliation);
+			expect(master.affiliation.type).toBe("master");
 			expect(master.studentId.getValue()).toBe("725A0099");
 		});
 
@@ -232,7 +228,7 @@ describe("ActiveMember", () => {
 				newStudentId,
 			);
 
-			expect(doctoral.affiliation).toBeInstanceOf(DoctoralAffiliation);
+			expect(doctoral.affiliation.type).toBe("doctoral");
 		});
 
 		it("学部生が博士に進学しようとするとエラー", () => {
@@ -282,15 +278,18 @@ describe("ActiveMember", () => {
 				studentId: createStudentId(),
 				affiliation: createUndergraduateAffiliation(),
 			});
-			const newAffiliation = new UndergraduateAffiliation({
-				faculty: "工学部",
-				department: "機械工学科",
-				course: "宇宙・環境コース",
-				year: 3,
-			});
+			const newAffiliation: UndergraduateAffiliation = {
+				type: "undergraduate",
+				value: {
+					faculty: "工学部",
+					department: "機械工学科",
+					course: "宇宙・環境コース",
+					year: 3,
+				},
+			};
 			const transferred = member.transferFaculty(newAffiliation);
 
-			expect(transferred.affiliation).toBeInstanceOf(UndergraduateAffiliation);
+			expect(transferred.affiliation.type).toBe("undergraduate");
 		});
 
 		it("大学院生は転学部できない", () => {
@@ -302,12 +301,15 @@ describe("ActiveMember", () => {
 				studentId: createStudentId(),
 				affiliation: createMasterAffiliation(),
 			});
-			const newAffiliation = new UndergraduateAffiliation({
-				faculty: "工学部",
-				department: "機械工学科",
-				course: "宇宙・環境コース",
-				year: 3,
-			});
+			const newAffiliation: UndergraduateAffiliation = {
+				type: "undergraduate",
+				value: {
+					faculty: "工学部",
+					department: "機械工学科",
+					course: "宇宙・環境コース",
+					year: 3,
+				},
+			};
 
 			expect(() => member.transferFaculty(newAffiliation)).toThrow(
 				InvalidAffiliationOperationException,
@@ -325,14 +327,13 @@ describe("ActiveMember", () => {
 				studentId: createStudentId(),
 				affiliation: createUndergraduateAffiliation(),
 			});
-			const newAffiliation = new UndergraduateAffiliation({
-				faculty: "情報学部",
-				department: "行動情報学科",
-				year: 3,
-			});
+			const newAffiliation: UndergraduateAffiliation = {
+				type: "undergraduate",
+				value: { faculty: "情報学部", department: "行動情報学科", year: 3 },
+			};
 			const transferred = member.transferDepartment(newAffiliation);
 
-			expect(transferred.affiliation).toBeInstanceOf(UndergraduateAffiliation);
+			expect(transferred.affiliation.type).toBe("undergraduate");
 		});
 
 		it("別学部への転学科はエラー", () => {
@@ -344,12 +345,15 @@ describe("ActiveMember", () => {
 				studentId: createStudentId(),
 				affiliation: createUndergraduateAffiliation(),
 			});
-			const newAffiliation = new UndergraduateAffiliation({
-				faculty: "工学部",
-				department: "機械工学科",
-				course: "宇宙・環境コース",
-				year: 3,
-			});
+			const newAffiliation: UndergraduateAffiliation = {
+				type: "undergraduate",
+				value: {
+					faculty: "工学部",
+					department: "機械工学科",
+					course: "宇宙・環境コース",
+					year: 3,
+				},
+			};
 
 			expect(() => member.transferDepartment(newAffiliation)).toThrow(
 				InvalidAffiliationOperationException,
@@ -367,15 +371,18 @@ describe("ActiveMember", () => {
 				studentId: createStudentId(),
 				affiliation: createMasterAffiliation(),
 			});
-			const newAffiliation = new MasterAffiliation({
-				school: "総合科学技術研究科",
-				major: "工学専攻",
-				course: "機械工学コース",
-				year: 1,
-			});
+			const newAffiliation: MasterAffiliation = {
+				type: "master",
+				value: {
+					school: "総合科学技術研究科",
+					major: "工学専攻",
+					course: "機械工学コース",
+					year: 1,
+				},
+			};
 			const transferred = member.transferMajor(newAffiliation);
 
-			expect(transferred.affiliation).toBeInstanceOf(MasterAffiliation);
+			expect(transferred.affiliation.type).toBe("master");
 		});
 
 		it("学部生は転専攻できない", () => {
@@ -402,12 +409,15 @@ describe("ActiveMember", () => {
 				studentId: createStudentId(),
 				affiliation: createMasterAffiliation(),
 			});
-			const newAffiliation = new MasterAffiliation({
-				school: "人文社会科学研究科",
-				major: "経済専攻",
-				course: "国際経営コース",
-				year: 1,
-			});
+			const newAffiliation: MasterAffiliation = {
+				type: "master",
+				value: {
+					school: "人文社会科学研究科",
+					major: "経済専攻",
+					course: "国際経営コース",
+					year: 1,
+				},
+			};
 
 			expect(() => member.transferMajor(newAffiliation)).toThrow(
 				InvalidAffiliationOperationException,
@@ -498,7 +508,7 @@ describe("FormerMember", () => {
 
 			expect(active.status).toBe("active");
 			expect(active.studentId.getValue()).toBe("725A0001");
-			expect(active.affiliation).toBeInstanceOf(MasterAffiliation);
+			expect(active.affiliation.type).toBe("master");
 		});
 
 		it("MemberReregisteredイベントが発行される", () => {


### PR DESCRIPTION
## Why

Affiliationが`ValueObject`クラスだったため、JSONB永続化に`SerializedAffiliation`型と`serialize/deserialize`関数が必要だった。ドメイン型を直接シリアライズ可能にし、インフラ層の変換コードを削減する。

## What

- `UndergraduateAffiliation`等をクラスからplain typeのdiscriminated unionに変更
- `SerializedAffiliation`型を削除（`Affiliation`型がそのままJSONBに格納可能に）
- `serializeAffiliation()` / `deserializeAffiliation()`を削除
- `affiliationTypeNames`マップを追加（表示名のドメイン知識をAffiliation.tsに集約）
- `Member.ts`の全`instanceof`分岐を`type`フィールド分岐に統一
- `DrizzleMemberRepository`からAffiliation変換コードを削除

## How

`Affiliation = { type: "undergraduate"; value: UndergraduateAffiliationValue } | ...` のdiscriminated unionにすることで、型自体がシリアライズ可能な形を持つ。`validate()`が全て空だったため、クラスを残す理由がなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)