### PR TITLE
feat!: 公開APIにファサード層を追加 (#97, #89)

### DIFF
--- a/src/executable/event.ts
+++ b/src/executable/event.ts
@@ -28,6 +28,7 @@ export type EventUseCases = {
 };
 
 /**
+ * @deprecated createEventService() を使用してください
  * @beta 将来的にAPIが変更される可能性があります。
  */
 export function createEventUseCases(): EventUseCases {

--- a/src/executable/eventService.ts
+++ b/src/executable/eventService.ts
@@ -1,0 +1,271 @@
+import * as eventUsecases from "#application";
+import * as eventParticipationUsecases from "#application";
+import type { Event } from "#domain/aggregates/event/Event";
+import { eventId } from "#domain/aggregates/event/EventId";
+import type { EventRepository } from "#domain/aggregates/event/EventRepository";
+import type { Exhibit } from "#domain/aggregates/event/Exhibit";
+import { exhibitId } from "#domain/aggregates/event/ExhibitId";
+import { LightningTalkDuration } from "#domain/aggregates/event/LightningTalkDuration";
+import { Url } from "#domain/aggregates/event/Url";
+import type { Member } from "#domain/aggregates/member/Member";
+import { memberId } from "#domain/aggregates/member/MemberId";
+import type { MemberRepository } from "#domain/aggregates/member/MemberRepository";
+import { DrizzleEventRepository, DrizzleMemberRepository } from "#infrastructure";
+
+export type EventService = {
+	create(input: { id: string; name: string; date: Date }): Promise<{ event: Event }>;
+
+	update(input: { eventId: string; name?: string; date?: Date }): Promise<{ event: Event }>;
+
+	delete(eventId: string): Promise<{ event: Event }>;
+
+	getById(eventId: string): Promise<{ event: Event | null }>;
+
+	list(): Promise<{ events: Event[] }>;
+
+	addExhibit(input: {
+		eventId: string;
+		exhibit: {
+			id: string;
+			name: string;
+			description?: string;
+			markdownContent?: string;
+			url?: string;
+		};
+	}): Promise<{ event: Event }>;
+
+	removeExhibit(input: { eventId: string; exhibitId: string }): Promise<{ event: Event }>;
+
+	changeExhibitName(input: {
+		eventId: string;
+		exhibitId: string;
+		newName: string;
+	}): Promise<{ event: Event }>;
+
+	changeExhibitDescription(input: {
+		eventId: string;
+		exhibitId: string;
+		newDescription: string;
+	}): Promise<{ event: Event }>;
+
+	changeExhibitMarkdownContent(input: {
+		eventId: string;
+		exhibitId: string;
+		newMarkdownContent: string;
+	}): Promise<{ event: Event }>;
+
+	changeExhibitUrl(input: {
+		eventId: string;
+		exhibitId: string;
+		newUrl: string;
+	}): Promise<{ event: Event }>;
+
+	changeLightningTalkDuration(input: {
+		eventId: string;
+		exhibitId: string;
+		newDuration: number;
+	}): Promise<{ event: Event }>;
+
+	changeLightningTalkSlideUrl(input: {
+		eventId: string;
+		exhibitId: string;
+		newSlideUrl: string;
+	}): Promise<{ event: Event }>;
+
+	changeLightningTalkStartTime(input: {
+		eventId: string;
+		exhibitId: string;
+		newStartTime: Date;
+	}): Promise<{ event: Event }>;
+
+	registerMemberToEvent(input: { memberId: string; eventId: string }): Promise<{ event: Event }>;
+
+	removeMemberFromEvent(input: { memberId: string; eventId: string }): Promise<{ event: Event }>;
+
+	getEventsByMember(memberIdValue: string): Promise<{ events: Event[] }>;
+
+	getMembersByEvent(eventIdValue: string): Promise<{ members: Member[] }>;
+
+	registerMemberToExhibit(input: {
+		memberId: string;
+		exhibitId: string;
+	}): Promise<{ event: Event }>;
+
+	removeMemberFromExhibit(input: {
+		memberId: string;
+		exhibitId: string;
+	}): Promise<{ event: Event }>;
+
+	getExhibitsByMember(memberIdValue: string): Promise<{ exhibits: Exhibit[] }>;
+
+	getMembersByExhibit(exhibitIdValue: string): Promise<{ members: Member[] }>;
+};
+
+export type EventServiceDeps = {
+	eventRepository?: EventRepository;
+	memberRepository?: MemberRepository;
+};
+
+export function createEventService(deps?: EventServiceDeps): EventService {
+	const eventRepo = deps?.eventRepository ?? new DrizzleEventRepository();
+	const memberRepo = deps?.memberRepository ?? new DrizzleMemberRepository();
+
+	const createEvent = new eventUsecases.CreateEvent(eventRepo);
+	const updateEvent = new eventUsecases.UpdateEvent(eventRepo);
+	const deleteEvent = new eventUsecases.DeleteEvent(eventRepo);
+	const getEvent = new eventUsecases.GetEvent(eventRepo);
+	const getEventList = new eventUsecases.GetEventList(eventRepo);
+	const addExhibitToEvent = new eventUsecases.AddExhibitToEvent(eventRepo);
+	const removeExhibitFromEvent = new eventUsecases.RemoveExhibitFromEvent(eventRepo);
+	const changeExhibitName = new eventUsecases.ChangeExhibitName(eventRepo);
+	const changeExhibitDescription = new eventUsecases.ChangeExhibitDescription(eventRepo);
+	const changeExhibitMarkdownContent = new eventUsecases.ChangeExhibitMarkdownContent(eventRepo);
+	const changeExhibitUrl = new eventUsecases.ChangeExhibitUrl(eventRepo);
+	const changeLTDuration = new eventUsecases.ChangeLightningTalkDuration(eventRepo);
+	const changeLTSlideUrl = new eventUsecases.ChangeLightningTalkSlideUrl(eventRepo);
+	const changeLTStartTime = new eventUsecases.ChangeLightningTalkStartTime(eventRepo);
+	const registerMemberToEvent = new eventParticipationUsecases.RegisterMemberToEvent(
+		eventRepo,
+		memberRepo,
+	);
+	const removeMemberFromEvent = new eventParticipationUsecases.RemoveMemberFromEvent(
+		eventRepo,
+		memberRepo,
+	);
+	const getEventsByMember = new eventParticipationUsecases.GetEventsByMember(eventRepo);
+	const getMembersByEvent = new eventParticipationUsecases.GetMembersByEvent(eventRepo, memberRepo);
+	const registerMemberToExhibit = new eventParticipationUsecases.RegisterMemberToExhibit(
+		eventRepo,
+		memberRepo,
+	);
+	const removeMemberFromExhibit = new eventParticipationUsecases.RemoveMemberFromExhibit(
+		memberRepo,
+		eventRepo,
+	);
+	const getExhibitsByMember = new eventParticipationUsecases.GetExhibitsByMember(eventRepo);
+	const getMembersByExhibit = new eventParticipationUsecases.GetMembersByExhibit(
+		memberRepo,
+		eventRepo,
+	);
+
+	return {
+		create: (input) =>
+			createEvent.execute({
+				id: eventId(input.id),
+				name: input.name,
+				date: input.date,
+			}),
+
+		update: (input) =>
+			updateEvent.execute({
+				eventId: eventId(input.eventId),
+				name: input.name,
+				date: input.date,
+			}),
+
+		delete: (id) => deleteEvent.execute({ eventId: eventId(id) }),
+
+		getById: (id) => getEvent.execute({ eventId: eventId(id) }),
+
+		list: () => getEventList.execute({} as Record<string, never>),
+
+		addExhibit: (input) =>
+			addExhibitToEvent.execute({
+				eventId: eventId(input.eventId),
+				exhibit: {
+					id: exhibitId(input.exhibit.id),
+					name: input.exhibit.name,
+					description: input.exhibit.description,
+					markdownContent: input.exhibit.markdownContent,
+					url: input.exhibit.url ? new Url(input.exhibit.url) : undefined,
+				},
+			}),
+
+		removeExhibit: (input) =>
+			removeExhibitFromEvent.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+			}),
+
+		changeExhibitName: (input) =>
+			changeExhibitName.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+				newName: input.newName,
+			}),
+
+		changeExhibitDescription: (input) =>
+			changeExhibitDescription.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+				newDescription: input.newDescription,
+			}),
+
+		changeExhibitMarkdownContent: (input) =>
+			changeExhibitMarkdownContent.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+				newMarkdownContent: input.newMarkdownContent,
+			}),
+
+		changeExhibitUrl: (input) =>
+			changeExhibitUrl.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+				newUrl: new Url(input.newUrl),
+			}),
+
+		changeLightningTalkDuration: (input) =>
+			changeLTDuration.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+				newDuration: new LightningTalkDuration(input.newDuration),
+			}),
+
+		changeLightningTalkSlideUrl: (input) =>
+			changeLTSlideUrl.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+				newSlideUrl: new Url(input.newSlideUrl),
+			}),
+
+		changeLightningTalkStartTime: (input) =>
+			changeLTStartTime.execute({
+				eventId: eventId(input.eventId),
+				exhibitId: exhibitId(input.exhibitId),
+				newStartTime: input.newStartTime,
+			}),
+
+		registerMemberToEvent: (input) =>
+			registerMemberToEvent.execute({
+				memberId: memberId(input.memberId),
+				eventId: eventId(input.eventId),
+			}),
+
+		removeMemberFromEvent: (input) =>
+			removeMemberFromEvent.execute({
+				memberId: memberId(input.memberId),
+				eventId: eventId(input.eventId),
+			}),
+
+		getEventsByMember: (id) => getEventsByMember.execute({ memberId: memberId(id) }),
+
+		getMembersByEvent: (id) => getMembersByEvent.execute({ eventId: eventId(id) }),
+
+		registerMemberToExhibit: (input) =>
+			registerMemberToExhibit.execute({
+				memberId: memberId(input.memberId),
+				exhibitId: exhibitId(input.exhibitId),
+			}),
+
+		removeMemberFromExhibit: (input) =>
+			removeMemberFromExhibit.execute({
+				memberId: memberId(input.memberId),
+				exhibitId: exhibitId(input.exhibitId),
+			}),
+
+		getExhibitsByMember: (id) => getExhibitsByMember.execute({ memberId: memberId(id) }),
+
+		getMembersByExhibit: (id) => getMembersByExhibit.execute({ exhibitId: exhibitId(id) }),
+	};
+}

--- a/src/executable/index.ts
+++ b/src/executable/index.ts
@@ -1,3 +1,6 @@
 export * from "./member";
 export * from "./event";
 export * from "./karte";
+export * from "./memberService";
+export * from "./eventService";
+export * from "./karteService";

--- a/src/executable/karte.ts
+++ b/src/executable/karte.ts
@@ -15,6 +15,7 @@ export type KarteUseCases = {
 	listKartes: ListKartesUseCase;
 };
 
+/** @deprecated createKarteService() を使用してください */
 export function createKarteUseCases(): KarteUseCases {
 	const karteRepo = new DrizzleKarteRepository();
 

--- a/src/executable/karteService.ts
+++ b/src/executable/karteService.ts
@@ -1,0 +1,184 @@
+import {
+	CorrectKarteUseCase,
+	CreateKarteUseCase,
+	GetKarteUseCase,
+	ImportKarteUseCase,
+	ListKartesUseCase,
+} from "#application";
+import type { Karte } from "#domain/aggregates/karte/Karte";
+import { karteId } from "#domain/aggregates/karte/KarteId";
+import type { KarteRepository } from "#domain/aggregates/karte/KarteRepository";
+import { memberId } from "#domain/aggregates/member/MemberId";
+import { nonEmptyString } from "#domain/base/NonEmptyString";
+import { workDuration } from "#domain/aggregates/karte/WorkDuration";
+import { StudentId } from "#domain/shared/StudentId";
+import { DrizzleKarteRepository } from "#infrastructure";
+import type { CompleteAffiliation } from "#domain/shared/affiliation/Affiliation";
+import type { Consent } from "#domain/aggregates/karte/Consent";
+import type { ConsultedAt } from "#domain/aggregates/karte/ConsultedAt";
+import type { ConsultationCategory } from "#domain/aggregates/karte/ConsultationCategory";
+import type { CompleteResolution } from "#domain/aggregates/karte/Karte";
+import type { Client } from "#domain/aggregates/karte/Client";
+import type { Consultation } from "#domain/aggregates/karte/Consultation";
+import type { Recorded } from "#domain/shared/Recorded";
+import type { SupportRecord } from "#domain/aggregates/karte/SupportRecord";
+
+// ============================================================================
+// Facade Input Types
+// ============================================================================
+
+/**
+ * ファサード用のクライアント入力型
+ *
+ * CompleteClientからStudentIdをstring化したもの。
+ * CompleteAffiliation等のplain object unionはそのまま保持する。
+ */
+type ClientInput =
+	| {
+			type: "student";
+			studentId: string;
+			name: string;
+			affiliation: CompleteAffiliation;
+	  }
+	| { type: "teacher"; name: string }
+	| { type: "staff"; name: string }
+	| { type: "other"; name: string };
+
+/** create / correct 共通の入力型 */
+type KarteContentInput = {
+	consultedAt: ConsultedAt;
+	client: ClientInput;
+	consent: Consent;
+	consultation: {
+		categories: ConsultationCategory[];
+		targetDevice: string;
+		troubleDetails: string;
+	};
+	supportRecord: {
+		assignedMemberIds: string[];
+		content: string;
+		resolution: CompleteResolution;
+		workDuration: number;
+	};
+};
+
+// ============================================================================
+// Service Type
+// ============================================================================
+
+export type KarteService = {
+	create(input: { id: string } & KarteContentInput): Promise<{ karte: Karte }>;
+
+	correct(input: { karteId: string } & KarteContentInput): Promise<{ karte: Karte }>;
+
+	getById(karteId: string): Promise<{ karte: Karte }>;
+
+	list(): Promise<{ kartes: readonly Karte[] }>;
+
+	import(input: {
+		id: string;
+		recordedAt: Date;
+		consultedAt: Recorded<ConsultedAt>;
+		lastUpdatedAt: Date;
+		client: Recorded<Client>;
+		consent: Consent;
+		consultation: Consultation;
+		supportRecord: SupportRecord;
+	}): Promise<{ karte: Karte }>;
+};
+
+export type KarteServiceDeps = {
+	karteRepository?: KarteRepository;
+};
+
+// ============================================================================
+// Input Conversion
+// ============================================================================
+
+function toCompleteClient(input: ClientInput) {
+	if (input.type === "student") {
+		return {
+			type: input.type,
+			name: input.name,
+			studentId: StudentId.fromString(input.studentId),
+			affiliation: input.affiliation,
+		} as const;
+	}
+	return input;
+}
+
+function toKarteContentProps(input: KarteContentInput) {
+	const [firstCategory, ...restCategories] = input.consultation.categories;
+	if (firstCategory === undefined) {
+		throw new Error("categories must have at least one element");
+	}
+
+	const [firstMemberId, ...restMemberIds] = input.supportRecord.assignedMemberIds;
+	if (firstMemberId === undefined) {
+		throw new Error("assignedMemberIds must have at least one element");
+	}
+
+	return {
+		consultedAt: input.consultedAt,
+		client: toCompleteClient(input.client),
+		consent: input.consent,
+		consultation: {
+			categories: [firstCategory, ...restCategories] as const,
+			targetDevice: nonEmptyString(input.consultation.targetDevice),
+			troubleDetails: nonEmptyString(input.consultation.troubleDetails),
+		},
+		supportRecord: {
+			assignedMemberIds: [
+				memberId(firstMemberId),
+				...restMemberIds.map((id) => memberId(id)),
+			] as const,
+			content: nonEmptyString(input.supportRecord.content),
+			resolution: input.supportRecord.resolution,
+			workDuration: workDuration(input.supportRecord.workDuration),
+		},
+	};
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+export function createKarteService(deps?: KarteServiceDeps): KarteService {
+	const karteRepo = deps?.karteRepository ?? new DrizzleKarteRepository();
+
+	const createKarte = new CreateKarteUseCase(karteRepo);
+	const correctKarte = new CorrectKarteUseCase(karteRepo);
+	const getKarte = new GetKarteUseCase(karteRepo);
+	const listKartes = new ListKartesUseCase(karteRepo);
+	const importKarte = new ImportKarteUseCase(karteRepo);
+
+	return {
+		create: (input) =>
+			createKarte.execute({
+				id: karteId(input.id),
+				...toKarteContentProps(input),
+			}),
+
+		correct: (input) =>
+			correctKarte.execute({
+				karteId: karteId(input.karteId),
+				...toKarteContentProps(input),
+			}),
+
+		getById: (id) => getKarte.execute({ karteId: karteId(id) }),
+
+		list: () => listKartes.execute({} as Record<string, never>),
+
+		import: (input) =>
+			importKarte.execute({
+				id: karteId(input.id),
+				recordedAt: input.recordedAt,
+				consultedAt: input.consultedAt,
+				lastUpdatedAt: input.lastUpdatedAt,
+				client: input.client,
+				consent: input.consent,
+				consultation: input.consultation,
+				supportRecord: input.supportRecord,
+			}),
+	};
+}

--- a/src/executable/member.ts
+++ b/src/executable/member.ts
@@ -21,6 +21,7 @@ export type MemberUseCases = {
 	connectDiscordAccount: ConnectDiscordAccountUseCase;
 };
 
+/** @deprecated createMemberService() を使用してください */
 export function createMemberUseCases(): MemberUseCases {
 	const memberRepo = new DrizzleMemberRepository();
 	const discordRepo = new DrizzleDiscordAccountRepository();

--- a/src/executable/memberService.ts
+++ b/src/executable/memberService.ts
@@ -1,0 +1,125 @@
+import {
+	ChangeDiscordNickNameUseCase,
+	ConnectDiscordAccountUseCase,
+	GetMemberByDiscordIdUseCase,
+	GetMemberByEmailUseCase,
+	GetMemberListUseCase,
+	GetMemberUseCase,
+	RegisterMemberUseCase,
+	UpdateMemberUseCase,
+} from "#application";
+import { discordId } from "#domain/aggregates/discord-account/DiscordId";
+import type { DiscordAccountRepository } from "#domain/aggregates/discord-account/DiscordAccountRepository";
+import type { DiscordAccount } from "#domain/aggregates/discord-account/DiscordAccount";
+import { Email } from "#domain/aggregates/member/Email";
+import type { Member } from "#domain/aggregates/member/Member";
+import { memberId } from "#domain/aggregates/member/MemberId";
+import type { MemberRepository } from "#domain/aggregates/member/MemberRepository";
+import { UniversityEmail } from "#domain/aggregates/member/UniversityEmail";
+import type { CompleteAffiliation } from "#domain/shared/affiliation/Affiliation";
+import { recorded, notRecorded } from "#domain/shared/Recorded";
+import { StudentId } from "#domain/shared/StudentId";
+import { DrizzleDiscordAccountRepository, DrizzleMemberRepository } from "#infrastructure";
+
+export type MemberService = {
+	register(input: {
+		name: string;
+		studentId: string;
+		email: string;
+		personalEmail?: string;
+		affiliation: CompleteAffiliation;
+	}): Promise<{ member: Member }>;
+
+	update(input: {
+		memberId: string;
+		name?: string;
+		studentId?: string;
+		personalEmail?: string | null;
+	}): Promise<{ member: Member }>;
+
+	getById(id: string): Promise<{ member: Member | null }>;
+
+	getByEmail(email: string): Promise<{ member: Member | null }>;
+
+	getByDiscordId(discordId: string): Promise<{ member: Member | null }>;
+
+	list(): Promise<{ members: Member[] }>;
+
+	connectDiscordAccount(input: {
+		memberId: string;
+		discordAccountId: string;
+		discordNickName: string;
+	}): Promise<{ discordAccount: DiscordAccount }>;
+
+	changeDiscordNickName(input: {
+		discordAccountId: string;
+		discordNickName: string;
+	}): Promise<{ discordAccount: DiscordAccount }>;
+};
+
+export type MemberServiceDeps = {
+	memberRepository?: MemberRepository;
+	discordAccountRepository?: DiscordAccountRepository;
+};
+
+export function createMemberService(deps?: MemberServiceDeps): MemberService {
+	const memberRepo = deps?.memberRepository ?? new DrizzleMemberRepository();
+	const discordRepo = deps?.discordAccountRepository ?? new DrizzleDiscordAccountRepository();
+
+	const registerMember = new RegisterMemberUseCase(memberRepo);
+	const updateMember = new UpdateMemberUseCase(memberRepo);
+	const getMember = new GetMemberUseCase(memberRepo);
+	const getMemberByEmail = new GetMemberByEmailUseCase(memberRepo);
+	const getMemberByDiscordId = new GetMemberByDiscordIdUseCase(discordRepo, memberRepo);
+	const getMemberList = new GetMemberListUseCase(memberRepo);
+	const connectDiscordAccountUC = new ConnectDiscordAccountUseCase(memberRepo, discordRepo);
+	const changeDiscordNickNameUC = new ChangeDiscordNickNameUseCase(discordRepo);
+
+	return {
+		register: (input) =>
+			registerMember.execute({
+				name: input.name,
+				studentId: StudentId.fromString(input.studentId),
+				email: new UniversityEmail(input.email),
+				personalEmail:
+					input.personalEmail !== undefined
+						? recorded(new Email(input.personalEmail))
+						: notRecorded(),
+				affiliation: input.affiliation,
+			}),
+
+		update: (input) =>
+			updateMember.execute({
+				memberId: memberId(input.memberId),
+				name: input.name,
+				studentId: input.studentId ? StudentId.fromString(input.studentId) : undefined,
+				personalEmail:
+					input.personalEmail === null
+						? notRecorded()
+						: input.personalEmail !== undefined
+							? recorded(new Email(input.personalEmail))
+							: undefined,
+			}),
+
+		getById: (id) => getMember.execute({ id: memberId(id) }),
+
+		getByEmail: (email) => getMemberByEmail.execute({ email: new UniversityEmail(email) }),
+
+		getByDiscordId: (id) => getMemberByDiscordId.execute({ discordId: discordId(id) }),
+
+		list: () => getMemberList.execute({} as Record<string, never>),
+
+		connectDiscordAccount: (input) =>
+			connectDiscordAccountUC.execute({
+				memberId: memberId(input.memberId),
+				discordAccountId: discordId(input.discordAccountId),
+				discordNickName: input.discordNickName,
+			}),
+
+		changeDiscordNickName: (input) =>
+			changeDiscordNickNameUC.execute({
+				discordAccountId: discordId(input.discordAccountId),
+				discordNickName: input.discordNickName,
+			}),
+	};
+}


### PR DESCRIPTION
## Why
公開APIが内部アーキテクチャパターン（UseCase/execute）を露出しており、消費者にドメイン型の構築を強制していた。また、ファクトリがDrizzle実装をハードコードしておりテスタビリティに欠けていた。

## What
- `createMemberService(deps?)` / `createEventService(deps?)` ファサードを新設
- 消費者はプリミティブ値（string, number, Date）だけで操作可能に
- リポジトリをオプショナル引数で注入可能（DI対応）
- 旧API (`createMemberUseCases` / `createEventUseCases`) は `@deprecated`

### Before
```ts
const useCases = createMemberUseCases();
await useCases.registerMember.execute({
  name: "太郎",
  studentId: StudentId.fromString("725A1061"),
  email: new UniversityEmail("taro@shizuoka.ac.jp"),
  personalEmail: notRecorded(),
  affiliation: { type: "undergraduate", value: { ... } },
});
```

### After
```ts
const members = createMemberService();
await members.register({
  name: "太郎",
  studentId: "725A1061",
  email: "taro@shizuoka.ac.jp",
  affiliation: { type: "undergraduate", value: { ... } },
});
```

## Test plan
- [x] 既存テスト全64件パス
- [x] 型チェック通過（新ファサードにエラーなし）
- [ ] CIが通ること

Closes #97, Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/core/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
