### PR TITLE
build!: ビルドをtsupからtscに変更しTree Shakingを有効化

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,13 @@
 	"version": "2.1.2",
 	"description": "ITS core library",
 	"type": "module",
-	"main": "dist/index.cjs",
-	"module": "dist/index.js",
+	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
+	"sideEffects": false,
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
+			"import": "./dist/index.js"
 		}
 	},
 	"repository": {
@@ -22,7 +21,7 @@
 	},
 	"files": ["dist"],
 	"scripts": {
-		"build": "tsup && tsc-alias -p tsconfig.json --outDir dist",
+		"build": "tsc -p tsconfig.build.json; tsc-alias -p tsconfig.build.json --outDir dist",
 		"prepare": "npm run build",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"noEmit": false
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "tests", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- tsupの単一バンドル出力をtscのファイルごとコンパイルに変更
- `sideEffects: false` を追加し、バンドラがドメイン層のみをimport可能に
- CJS出力を廃止（ESMのみ）

## Why
tsupの単一バンドルではNext.jsクライアントコンポーネントからドメイン定数（`CONSULTATION_CATEGORIES`等）をimportすると、executable層→infrastructure層（drizzle/pg）が引き込まれて`dns`モジュールエラーが発生していた。

## Test plan
- [ ] `npm run build` が成功すること
- [ ] dist/にファイルごとの.js/.d.tsが出力されること
- [ ] Next.jsクライアントコンポーネントからcoreの値importが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/core/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
