### PR TITLE
ci: Drizzleスキーマと生成ファイルの同期チェックをCIに追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           if [ -n "$(git status --porcelain drizzle/)" ]; then
             echo "::error::Drizzle schema and generated files are out of sync. Run 'npm run db:generate' and commit the result."
+            git add -N drizzle/
             git diff drizzle/
-            git status drizzle/
             exit 1
           fi
 


### PR DESCRIPTION
## Why

スキーマ変更後に `npm run db:generate` を忘れてコミットすると、Drizzleスキーマと生成済みマイグレーションファイルに差異が生じる。これをCIで検出し、未然に防ぐ。

## What

CIワークフローに `drizzle-check` ジョブを追加。`drizzle-kit generate` を実行し `drizzle/` ディレクトリに差分が生じた場合、エラーメッセージとdiffを表示して失敗させる。

## Test plan

- [ ] CIの `drizzle-check` ジョブが正常に通ること
- [ ] スキーマを変更してgenerateせずにpushした場合にCIが失敗すること

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/core/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
