### PR TITLE
chore: TypeScript 6.0へアップグレード

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["dist", "drizzle"]
+		"ignore": ["dist", "drizzle", ".claude"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"drizzle-kit": "^0.31.8",
 				"tsc-alias": "^1.8.16",
 				"tsup": "^8.5.1",
-				"typescript": "^5.6.3",
+				"typescript": "^6.0.2",
 				"vitest": "^4.0.18"
 			}
 		},
@@ -3705,9 +3705,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"drizzle-kit": "^0.31.8",
 		"tsc-alias": "^1.8.16",
 		"tsup": "^8.5.1",
-		"typescript": "^5.6.3",
+		"typescript": "^6.0.2",
 		"vitest": "^4.0.18"
 	},
 	"dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,7 @@
 {
 	"compilerOptions": {
+		"ignoreDeprecations": "6.0",
 		"target": "ES2022",
-		"module": "ESNext",
-		"moduleResolution": "bundler",
-		"strict": true,
-		"esModuleInterop": true,
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",


### PR DESCRIPTION
## Why

TypeScript 6.0がリリースされ、デフォルト設定の改善（`strict: true`、`moduleResolution: "bundler"`等）やESMサポートの強化が含まれる。後続のビルド移行（#110）の前提として先にアップグレードする。

## What

- TypeScript `^5.6.3` → `^6.0.2`
- tsconfig.jsonからTS 6.0デフォルト設定を削除してスリム化（`strict`, `esModuleInterop`, `module`, `moduleResolution`）
- `ignoreDeprecations: "6.0"`を追加（`baseUrl`非推奨警告対応）
- biome.jsonに`.claude`ディレクトリをignore追加

## Test plan

- [x] `npm run typecheck` 成功
- [x] `npm run lint:ci` 成功
- [x] `npm run build` 成功
- [x] `npm test` 成功（112テスト全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/core/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
