### PR TITLE
fix(ci): drizzle-checkジョブを復元

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,22 @@ jobs:
       - uses: ./.github/actions/setup-node
       - run: vp test
 
+  drizzle-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-node
+      - run: npm run db:generate
+      - name: Check for uncommitted schema changes
+        run: |
+          if [ -n "$(git status --porcelain drizzle/)" ]; then
+            echo "::error::Drizzle schema and generated files are out of sync. Run 'npm run db:generate' and commit the result."
+            git add -N drizzle/
+            git diff drizzle/
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Why

PR #107（VP移行）のマージでdrizzle-checkジョブが欠落し、ブランチ保護の必須チェックが永遠にpendingになっていた。

## What

ci.ymlにdrizzle-checkジョブを復元。

## Test plan

- [x] CI通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/core/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
