### PR TITLE
chore: backmerge release/v3.0.0 into develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "2.1.2",
+  "version": "3.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shizuoka-its/core",
-      "version": "2.1.2",
+      "version": "3.0.0-rc.0",
       "license": "ISC",
       "dependencies": {
         "drizzle-orm": "^0.45.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shizuoka-its/core",
-  "version": "2.1.2",
+  "version": "3.0.0-rc.0",
   "description": "ITS core library",
   "keywords": [],
   "license": "ISC",


### PR DESCRIPTION
## Why
リリースブランチのバージョンバンプをdevelopに反映する。

## What
- バージョンを 3.0.0-rc.0 に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/core/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
