### PR TITLE
feat: AsyncLocalStorageを用いたUnit of Work基盤を導入

### DIFF
--- a/src/application/UnitOfWork.ts
+++ b/src/application/UnitOfWork.ts
@@ -1,0 +1,7 @@
+/**
+ * 一連の操作をまとめて扱うためのインターフェース
+ * 具体的な実装（DBトランザクション等）はInfrastructure層が担当する
+ */
+export interface UnitOfWork {
+	run<T>(fn: () => Promise<T>): Promise<T>;
+}

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -1,4 +1,5 @@
 export * from "./dto";
+export * from "./UnitOfWork";
 export * from "./usecase/member";
 export * from "./usecase/event";
 export * from "./usecase/eventParticipation";

--- a/src/application/usecase/base.ts
+++ b/src/application/usecase/base.ts
@@ -1,8 +1,32 @@
+import type { UnitOfWork } from "../UnitOfWork";
+
 /**
  * ユースケースの基底抽象クラス
  * TInputはユースケースへの入力型
  * TOutputはユースケースからの出力型
  */
 export abstract class IUseCase<Input, Output> {
+	/**
+	 * ユースケースのビジネスロジックを実行する
+	 * トランザクションなしで実行されるため、読み取り専用のUseCaseはこちらを使う
+	 * 複数のDB書き込みを安全にまとめたい場合は run() を使うこと
+	 */
 	abstract execute(input: Input): Promise<Output>;
+
+	/**
+	 * UnitOfWorkで囲んでexecuteを実行する
+	 * トランザクション内で全てのDB操作がまとめて成功/失敗する
+	 * 複数の集約をまたぐ書き込み操作がある場合に使用する
+	 *
+	 * 注意:
+	 * - execute()内で外部API呼び出し（Discord API等）を行うと、
+	 *   その応答待ちの間トランザクションが開きっぱなしになる
+	 *   外部連携はトランザクション完了後に行うこと
+	 * - トランザクションがロールバックされてもメモリ上のドメインオブジェクトは
+	 *   元に戻らない。execute()内で取得・変更したドメインオブジェクトを
+	 *   ロールバック後に再利用しないこと
+	 */
+	async run(input: Input, unitOfWork: UnitOfWork): Promise<Output> {
+		return unitOfWork.run(() => this.execute(input));
+	}
 }

--- a/src/infrastructure/drizzle/DrizzleDiscordAccountRepository.ts
+++ b/src/infrastructure/drizzle/DrizzleDiscordAccountRepository.ts
@@ -8,7 +8,7 @@ import {
 	discordId,
 	memberId,
 } from "#domain";
-import { getDb } from "./client";
+import { getClient } from "./client";
 import { discordAccountDomainEvents, discordAccounts } from "./schema";
 import { serializeDiscordAccountEventPayload } from "./serializeDiscordAccountEvent";
 
@@ -20,7 +20,7 @@ function toDomain(row: DiscordAccountRow): DiscordAccount {
 
 export class DrizzleDiscordAccountRepository implements DiscordAccountRepository {
 	async findByDiscordId(id: DiscordId): Promise<DiscordAccount | null> {
-		const db = getDb();
+		const db = getClient();
 		const row = await db.query.discordAccounts.findFirst({
 			where: eq(discordAccounts.discordId, id as string),
 		});
@@ -29,7 +29,7 @@ export class DrizzleDiscordAccountRepository implements DiscordAccountRepository
 	}
 
 	async findByMemberId(id: MemberId): Promise<DiscordAccount[]> {
-		const db = getDb();
+		const db = getClient();
 		const rows = await db.query.discordAccounts.findMany({
 			where: eq(discordAccounts.memberId, id as string),
 		});
@@ -43,7 +43,7 @@ export class DrizzleDiscordAccountRepository implements DiscordAccountRepository
 	}
 
 	async save(account: DiscordAccount): Promise<void> {
-		const db = getDb();
+		const db = getClient();
 		const now = new Date().toISOString();
 		const events = account.getDomainEvents();
 
@@ -80,7 +80,7 @@ export class DrizzleDiscordAccountRepository implements DiscordAccountRepository
 	}
 
 	async delete(id: DiscordId): Promise<void> {
-		const db = getDb();
+		const db = getClient();
 		await db.delete(discordAccounts).where(eq(discordAccounts.discordId, id as string));
 	}
 }

--- a/src/infrastructure/drizzle/DrizzleDiscordAccountRepository.ts
+++ b/src/infrastructure/drizzle/DrizzleDiscordAccountRepository.ts
@@ -37,7 +37,7 @@ export class DrizzleDiscordAccountRepository implements DiscordAccountRepository
 	}
 
 	async findAll(): Promise<DiscordAccount[]> {
-		const db = getDb();
+		const db = getClient();
 		const rows = await db.query.discordAccounts.findMany();
 		return rows.map(toDomain);
 	}

--- a/src/infrastructure/drizzle/DrizzleEventRepository.ts
+++ b/src/infrastructure/drizzle/DrizzleEventRepository.ts
@@ -14,7 +14,7 @@ import {
 	exhibitId,
 	memberId,
 } from "#domain";
-import { type DrizzleDb, getDb } from "./client";
+import { type DrizzleClient, getClient } from "./client";
 import { events, exhibits, lightningTalks, memberEvents, memberExhibits } from "./schema";
 
 // ============================================================================
@@ -101,7 +101,7 @@ export class DrizzleEventRepository implements EventRepository {
 	// ==========================================================================
 
 	private async persistEvent(event: Event): Promise<void> {
-		const db = getDb();
+		const db = getClient();
 		const snapshot = event.toSnapshot();
 		const now = new Date().toISOString();
 		const dateStr = snapshot.date instanceof Date ? snapshot.date.toISOString() : snapshot.date;
@@ -143,7 +143,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	private async deleteObsoleteExhibits(
-		db: DrizzleDb,
+		db: DrizzleClient,
 		eventId: EventId,
 		keptExhibitIds: ExhibitId[],
 	): Promise<void> {
@@ -164,7 +164,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	private async upsertExhibit(
-		db: DrizzleDb,
+		db: DrizzleClient,
 		eventId: EventId,
 		ex: ReturnType<Event["toSnapshot"]>["exhibits"][number],
 	): Promise<void> {
@@ -220,7 +220,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	private async syncMemberEvents(
-		db: DrizzleDb,
+		db: DrizzleClient,
 		eventId: EventId,
 		memberIds: MemberId[],
 	): Promise<void> {
@@ -241,7 +241,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	private async syncMemberExhibits(
-		db: DrizzleDb,
+		db: DrizzleClient,
 		exhibitId: ExhibitId,
 		memberIds: MemberId[],
 	): Promise<void> {
@@ -266,7 +266,7 @@ export class DrizzleEventRepository implements EventRepository {
 	// ==========================================================================
 
 	async findById(id: EventId): Promise<Event | null> {
-		const db = getDb();
+		const db = getClient();
 		const record = await db.query.events.findFirst({
 			where: eq(events.id, id),
 			with: {
@@ -285,7 +285,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	async findByParticipantMemberId(memberId: MemberId): Promise<Event[]> {
-		const db = getDb();
+		const db = getClient();
 
 		const participations = await db
 			.select({ eventId: memberEvents.eventId })
@@ -312,7 +312,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	async findByExhibitId(exhibitId: ExhibitId): Promise<Event | null> {
-		const db = getDb();
+		const db = getClient();
 
 		const exhibit = await db
 			.select({ eventId: exhibits.eventId })
@@ -325,7 +325,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	async findAll(): Promise<Event[]> {
-		const db = getDb();
+		const db = getClient();
 		const records = await db.query.events.findMany({
 			with: {
 				memberEvents: true,
@@ -346,7 +346,7 @@ export class DrizzleEventRepository implements EventRepository {
 	}
 
 	async delete(eventId: EventId): Promise<void> {
-		const db = getDb();
+		const db = getClient();
 
 		const exhibitRecords = await db
 			.select({ id: exhibits.id })

--- a/src/infrastructure/drizzle/DrizzleKarteRepository.ts
+++ b/src/infrastructure/drizzle/DrizzleKarteRepository.ts
@@ -21,7 +21,7 @@ import {
 	type Resolution,
 	type SupportRecord,
 } from "#domain";
-import { getDb } from "./client";
+import { getClient } from "./client";
 import { karteAssignees, kartes } from "./schema";
 
 // ============================================================================
@@ -250,7 +250,7 @@ function consultedAtToPrecision(r: Recorded<ConsultedAt>): ConsultedAt["precisio
 
 export class DrizzleKarteRepository implements KarteRepository {
 	async findById(id: KarteId): Promise<Karte | null> {
-		const db = getDb();
+		const db = getClient();
 		const row = await db.query.kartes.findFirst({
 			where: eq(kartes.id, id as string),
 			with: {
@@ -263,7 +263,7 @@ export class DrizzleKarteRepository implements KarteRepository {
 	}
 
 	async findAll(): Promise<Karte[]> {
-		const db = getDb();
+		const db = getClient();
 		const rows = await db.query.kartes.findMany({
 			with: {
 				karteAssignees: true,
@@ -274,7 +274,7 @@ export class DrizzleKarteRepository implements KarteRepository {
 	}
 
 	async save(karte: Karte): Promise<void> {
-		const db = getDb();
+		const db = getClient();
 
 		const clientCols = clientToColumns(karte.client);
 		const resCols = resolutionToColumns(karte.supportRecord.resolution);

--- a/src/infrastructure/drizzle/DrizzleMemberRepository.ts
+++ b/src/infrastructure/drizzle/DrizzleMemberRepository.ts
@@ -16,7 +16,7 @@ import {
 	type MemberRepository,
 	type Recorded,
 } from "#domain";
-import { getDb } from "./client";
+import { getClient } from "./client";
 import { memberDomainEvents, members } from "./schema";
 import { serializeMemberEventPayload } from "./serializeMemberEvent";
 
@@ -100,7 +100,7 @@ function toInsertValues(member: Member): MemberInsert {
 
 export class DrizzleMemberRepository implements MemberRepository {
 	async findById(id: MemberId): Promise<Member | null> {
-		const db = getDb();
+		const db = getClient();
 		const row = await db.query.members.findFirst({
 			where: eq(members.id, id as string),
 		});
@@ -109,7 +109,7 @@ export class DrizzleMemberRepository implements MemberRepository {
 	}
 
 	async findByEmail(email: UniversityEmail): Promise<Member | null> {
-		const db = getDb();
+		const db = getClient();
 		const row = await db.query.members.findFirst({
 			where: eq(members.email, email.getValue()),
 		});
@@ -118,13 +118,13 @@ export class DrizzleMemberRepository implements MemberRepository {
 	}
 
 	async findAll(): Promise<Member[]> {
-		const db = getDb();
+		const db = getClient();
 		const rows = await db.query.members.findMany();
 		return rows.map(toDomain);
 	}
 
 	async save(member: Member): Promise<void> {
-		const db = getDb();
+		const db = getClient();
 		const values = toInsertValues(member);
 		const events = member.getDomainEvents();
 

--- a/src/infrastructure/drizzle/DrizzleUnitOfWork.ts
+++ b/src/infrastructure/drizzle/DrizzleUnitOfWork.ts
@@ -1,0 +1,12 @@
+import type { UnitOfWork } from "#application/UnitOfWork";
+import { runInTransaction } from "./client";
+
+/**
+ * UnitOfWorkのDrizzle実装
+ * AsyncLocalStorageを利用して、トランザクションを処理の流れ全体で共有する
+ */
+export class DrizzleUnitOfWork implements UnitOfWork {
+	async run<T>(fn: () => Promise<T>): Promise<T> {
+		return runInTransaction(fn);
+	}
+}

--- a/src/infrastructure/drizzle/client.ts
+++ b/src/infrastructure/drizzle/client.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 import { AsyncLocalStorage } from "node:async_hooks";
+<<<<<<< HEAD
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js/session";
@@ -7,6 +8,17 @@ import postgres, { type Sql } from "postgres";
 import * as schema from "./schema";
 
 export type DrizzleDb = PgDatabase<PostgresJsQueryResultHKT, typeof schema>;
+=======
+import type { NodePgQueryResultHKT } from "drizzle-orm/node-postgres";
+import { drizzle } from "drizzle-orm/node-postgres";
+import type { PgDatabase } from "drizzle-orm/pg-core";
+import { Pool } from "pg";
+import * as schema from "./schema";
+
+export type DrizzleClient = PgDatabase<NodePgQueryResultHKT, typeof schema>;
+
+let pool: Pool | null = null;
+>>>>>>> 6d5f1a6 (refactor: DrizzleClientをPgDatabase型で定義しトランザクションの強制キャストを除去)
 
 let sqlClient: Sql | null = null;
 
@@ -23,6 +35,7 @@ function getSqlClient(): Sql {
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 function createDb() {
 	return drizzle(getSqlClient(), { schema });
 }
@@ -30,10 +43,11 @@ function createDb() {
 const transactionContext = new AsyncLocalStorage<DrizzleDb>();
 =======
 function createClient() {
+=======
+function createClient(): DrizzleClient {
+>>>>>>> 6d5f1a6 (refactor: DrizzleClientをPgDatabase型で定義しトランザクションの強制キャストを除去)
 	return drizzle(getPool(), { schema });
 }
-
-export type DrizzleClient = ReturnType<typeof createClient>;
 
 const transactionContext = new AsyncLocalStorage<DrizzleClient>();
 >>>>>>> 91008a2 (refactor: getDb/createDb/DrizzleDb を getClient/createClient/DrizzleClient にリネーム)
@@ -60,9 +74,13 @@ export function runInTransaction<T>(fn: () => Promise<T>): Promise<T> {
 	const db = createClient();
 	return db.transaction(async (tx) => {
 <<<<<<< HEAD
+<<<<<<< HEAD
 		return transactionContext.run(tx, fn);
 =======
 		return transactionContext.run(tx as unknown as DrizzleClient, fn);
 >>>>>>> 91008a2 (refactor: getDb/createDb/DrizzleDb を getClient/createClient/DrizzleClient にリネーム)
+=======
+		return transactionContext.run(tx, fn);
+>>>>>>> 6d5f1a6 (refactor: DrizzleClientをPgDatabase型で定義しトランザクションの強制キャストを除去)
 	});
 }

--- a/src/infrastructure/drizzle/client.ts
+++ b/src/infrastructure/drizzle/client.ts
@@ -22,21 +22,31 @@ function getSqlClient(): Sql {
 	return sqlClient;
 }
 
+<<<<<<< HEAD
 function createDb() {
 	return drizzle(getSqlClient(), { schema });
 }
 
 const transactionContext = new AsyncLocalStorage<DrizzleDb>();
+=======
+function createClient() {
+	return drizzle(getPool(), { schema });
+}
+
+export type DrizzleClient = ReturnType<typeof createClient>;
+
+const transactionContext = new AsyncLocalStorage<DrizzleClient>();
+>>>>>>> 91008a2 (refactor: getDb/createDb/DrizzleDb を getClient/createClient/DrizzleClient にリネーム)
 
 /**
- * DB接続を取得する
+ * Drizzleクライアントを取得する
  * トランザクション中であればそのトランザクションを返し、
- * そうでなければ新しいDB接続を返す
+ * そうでなければ新しいクライアントを返す
  */
-export function getDb(): DrizzleDb {
+export function getClient(): DrizzleClient {
 	const tx = transactionContext.getStore();
 	if (tx) return tx;
-	return createDb();
+	return createClient();
 }
 
 /**
@@ -47,8 +57,12 @@ export function runInTransaction<T>(fn: () => Promise<T>): Promise<T> {
 	if (transactionContext.getStore()) {
 		return fn();
 	}
-	const db = createDb();
+	const db = createClient();
 	return db.transaction(async (tx) => {
+<<<<<<< HEAD
 		return transactionContext.run(tx, fn);
+=======
+		return transactionContext.run(tx as unknown as DrizzleClient, fn);
+>>>>>>> 91008a2 (refactor: getDb/createDb/DrizzleDb を getClient/createClient/DrizzleClient にリネーム)
 	});
 }

--- a/src/infrastructure/drizzle/client.ts
+++ b/src/infrastructure/drizzle/client.ts
@@ -1,24 +1,54 @@
 /// <reference types="node" />
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { PgDatabase } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/postgres-js";
+import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js/session";
 import postgres, { type Sql } from "postgres";
 import * as schema from "./schema";
 
-let client: Sql | null = null;
+export type DrizzleDb = PgDatabase<PostgresJsQueryResultHKT, typeof schema>;
 
-function getClient(): Sql {
-	if (!client) {
+let sqlClient: Sql | null = null;
+
+function getSqlClient(): Sql {
+	if (!sqlClient) {
 		const connectionString = process.env.DATABASE_URL;
 		if (!connectionString) {
 			throw new Error("DATABASE_URL environment variable is not set");
 		}
 		// Supabase の Transaction pool mode は prepared statement をサポートしないため無効化
-		client = postgres(connectionString, { prepare: false });
+		sqlClient = postgres(connectionString, { prepare: false });
 	}
-	return client;
+	return sqlClient;
 }
 
-export function getDb() {
-	return drizzle(getClient(), { schema });
+function createDb() {
+	return drizzle(getSqlClient(), { schema });
 }
 
-export type DrizzleDb = ReturnType<typeof getDb>;
+const transactionContext = new AsyncLocalStorage<DrizzleDb>();
+
+/**
+ * DB接続を取得する
+ * トランザクション中であればそのトランザクションを返し、
+ * そうでなければ新しいDB接続を返す
+ */
+export function getDb(): DrizzleDb {
+	const tx = transactionContext.getStore();
+	if (tx) return tx;
+	return createDb();
+}
+
+/**
+ * トランザクション内で処理を実行する
+ * すでにトランザクション中であればそのまま実行する（ネストしない）
+ */
+export function runInTransaction<T>(fn: () => Promise<T>): Promise<T> {
+	if (transactionContext.getStore()) {
+		return fn();
+	}
+	const db = createDb();
+	return db.transaction(async (tx) => {
+		return transactionContext.run(tx, fn);
+	});
+}

--- a/src/infrastructure/drizzle/client.ts
+++ b/src/infrastructure/drizzle/client.ts
@@ -1,24 +1,12 @@
 /// <reference types="node" />
 import { AsyncLocalStorage } from "node:async_hooks";
-<<<<<<< HEAD
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js/session";
 import postgres, { type Sql } from "postgres";
 import * as schema from "./schema";
 
-export type DrizzleDb = PgDatabase<PostgresJsQueryResultHKT, typeof schema>;
-=======
-import type { NodePgQueryResultHKT } from "drizzle-orm/node-postgres";
-import { drizzle } from "drizzle-orm/node-postgres";
-import type { PgDatabase } from "drizzle-orm/pg-core";
-import { Pool } from "pg";
-import * as schema from "./schema";
-
-export type DrizzleClient = PgDatabase<NodePgQueryResultHKT, typeof schema>;
-
-let pool: Pool | null = null;
->>>>>>> 6d5f1a6 (refactor: DrizzleClientをPgDatabase型で定義しトランザクションの強制キャストを除去)
+export type DrizzleClient = PgDatabase<PostgresJsQueryResultHKT, typeof schema>;
 
 let sqlClient: Sql | null = null;
 
@@ -34,23 +22,11 @@ function getSqlClient(): Sql {
 	return sqlClient;
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-function createDb() {
+function createClient(): DrizzleClient {
 	return drizzle(getSqlClient(), { schema });
 }
 
-const transactionContext = new AsyncLocalStorage<DrizzleDb>();
-=======
-function createClient() {
-=======
-function createClient(): DrizzleClient {
->>>>>>> 6d5f1a6 (refactor: DrizzleClientをPgDatabase型で定義しトランザクションの強制キャストを除去)
-	return drizzle(getPool(), { schema });
-}
-
 const transactionContext = new AsyncLocalStorage<DrizzleClient>();
->>>>>>> 91008a2 (refactor: getDb/createDb/DrizzleDb を getClient/createClient/DrizzleClient にリネーム)
 
 /**
  * Drizzleクライアントを取得する
@@ -73,14 +49,6 @@ export function runInTransaction<T>(fn: () => Promise<T>): Promise<T> {
 	}
 	const db = createClient();
 	return db.transaction(async (tx) => {
-<<<<<<< HEAD
-<<<<<<< HEAD
 		return transactionContext.run(tx, fn);
-=======
-		return transactionContext.run(tx as unknown as DrizzleClient, fn);
->>>>>>> 91008a2 (refactor: getDb/createDb/DrizzleDb を getClient/createClient/DrizzleClient にリネーム)
-=======
-		return transactionContext.run(tx, fn);
->>>>>>> 6d5f1a6 (refactor: DrizzleClientをPgDatabase型で定義しトランザクションの強制キャストを除去)
 	});
 }

--- a/src/infrastructure/drizzle/index.ts
+++ b/src/infrastructure/drizzle/index.ts
@@ -2,3 +2,4 @@ export { DrizzleDiscordAccountRepository } from "./DrizzleDiscordAccountReposito
 export { DrizzleEventRepository } from "./DrizzleEventRepository";
 export { DrizzleKarteRepository } from "./DrizzleKarteRepository";
 export { DrizzleMemberRepository } from "./DrizzleMemberRepository";
+export { DrizzleUnitOfWork } from "./DrizzleUnitOfWork";


### PR DESCRIPTION
## Summary

複数の集約をまたぐDB操作をトランザクションで安全にまとめるための Unit of Work（UoW）基盤を導入します。
AsyncLocalStorageを利用して、トランザクションを処理の流れ全体で暗黙的に共有できるようにしました。

### 変更内容

- **`UnitOfWork` インターフェース（Application層）**: 「操作をまとめて扱う」抽象的な契約。DB/トランザクションという概念は含まない
- **`DrizzleUnitOfWork`（Infrastructure層）**: UoWの具象実装。Drizzleのトランザクション + AsyncLocalStorageで実現
- **`client.ts` の変更**: `getDb()` がAsyncLocalStorageを確認し、トランザクション中ならそれを返す。すでにトランザクション中ならネストしない
- **`IUseCase` に `run()` メソッド追加**: `execute()` をUoWで囲んで実行する。既存コードへの破壊的変更なし

### 使い方

```typescript
// 従来通り（トランザクションなし）
await useCase.execute(input);

// トランザクションあり
const uow = new DrizzleUnitOfWork();
await useCase.run(input, uow);
```

## 既知の課題・相談したい点

### 1. `execute()` vs `run()` の選択が人間に委ねられている
`execute()` を直接呼んでもエラーにならないため、`run()` の使い忘れが起こりうる。
`execute()` を `protected` にして強制する案もあるが、読み取り専用UseCaseにもUoWが必要になるトレードオフがある。

### 2. Repository内部の既存トランザクションとのネスト
`DrizzleMemberRepository.save()` が内部で `db.transaction()` を直接使っている。
UoW経由のトランザクションが開始された状態で呼ばれるとSAVEPOINTによるネストが発生する。
→ 次のPRでRepository内部のトランザクションを整理予定

### 3. ドメインオブジェクトはロールバックされない
DBがロールバックされても、メモリ上のドメインオブジェクトは変更されたまま残る。
現状はUseCaseのexecute内でオブジェクトを取得→使い捨てにしているため問題は起きにくいが、
根本対策（出力をDTOにする / イミュータブル化）を検討すべきか？

### 4. 型キャスト `as unknown as DrizzleDb`
Drizzleのトランザクションオブジェクトと通常のDB接続は実行時に互換だが、TypeScript上は別の型。
強制キャストしているため、Drizzleのメジャーアップデートで型チェックをすり抜けて壊れる可能性がある（低リスク）。

### 5. テストが未実装
UoWの動作確認（ロールバック、ネスト防止）のインテグレーションテストがない。

## Test plan

- [ ] `npm run typecheck` が通ること
- [ ] `npm run lint` が通ること
- [ ] UoWのインテグレーションテストを追加する（別PR可）
- [ ] 既存のUseCaseが `execute()` で従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)