### PR TITLE
ci: prerelease バージョンの publish 時に --tag を自動付与するように修正 (#132)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,16 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
       - run: vp install
       - run: vp pack
-      - run: npm publish --access public
+      - name: Determine npm publish tag
+        id: tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -q '-'; then
+            PRERELEASE_ID=$(echo "$VERSION" | sed 's/.*-\([a-zA-Z]*\).*/\1/')
+            echo "tag=--tag $PRERELEASE_ID" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+          fi
+      - run: npm publish --access public ${{ steps.tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

prerelease バージョン（`3.0.0-rc.1` 等）を `npm publish` する際、`--tag` オプションが未指定のため publish が失敗する。
https://github.com/su-its/core/actions/runs/23796409089/job/69344776248

## What

package.json のバージョンにハイフンが含まれる場合、prerelease ID（`rc`, `beta` 等）を抽出して `--tag` に指定する。

- `3.0.0-rc.1` → `npm publish --access public --tag rc`
- `3.0.0-beta.1` → `npm publish --access public --tag beta`
- `3.0.0` → `npm publish --access public`（latest）

🤖 Generated with [Claude Code](https://claude.com/claude-code) <!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/su-its/core/pull/132" target="_blank">
  <picture>
<source media="(prefers-color-scheme: dark)"
srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1"> <img
src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->